### PR TITLE
Remove pip install instruction

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,12 +35,6 @@ It was developed to read the IMMA_ (International Maritime Meteorological Archiv
 Installation
 ------------
 
-You can install the package directly with pip:
-
-.. code-block:: console
-
-     pip install cdm
-
 If you want to contribute, I recommend cloning the repository and installing the package in development mode, e.g.
 
 .. code-block:: console


### PR DESCRIPTION
`pip install cdm` installs [https://pypi.org/project/cdm/](https://pypi.org/project/cdm/) which is not `cdm_mapper_reader`.

