### PR TITLE
logging: Allow for use of log file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -66,9 +66,9 @@ Run a test
 
 Read imma data with the `cdm.read()` and copy the data attributes:
 
-.. code-block:: console
+.. code-block:: python
 
-    import cdm
+    import cdm_reader_mapper as cdm
 
     data = cdm.tests.read_imma1_buoys_nosupp()
 
@@ -80,7 +80,7 @@ Read imma data with the `cdm.read()` and copy the data attributes:
 
 Map this data to a CDM build for the same deck (in this case deck 704: US Marine Metereological Journal collection of data):
 
-.. code-block:: console
+.. code-block:: python
 
     name_of_model = 'icoads_r3000_d704'
 

--- a/README.rst
+++ b/README.rst
@@ -46,6 +46,21 @@ If you want to contribute, I recommend cloning the repository and installing the
 This will install the package but you can still edit it and you don't need the package in your :code:`PYTHONPATH`
 
 
+Logging
+-------
+
+By default, :code:`cdm_reader_mapper` outputs logging information to :code:`STDOUT`. To tell :code:`cdm_reader_mapper` to output logs to a file, set the :code:`CDM_LOG_FILE` environment variable **before** loading :code:`cdm_reader_mapper`.
+
+.. code-block:: python
+
+   import os
+   os.environ['CDM_LOG_FILE'] = 'log_file.log'
+
+   import cdm_reader_mapper as cmd
+
+This will set the file :code:`log_file.log` as the output for all logging information from :code:`cdm_reader_mapper`, including the initial logging on loading of the package.
+
+
 Run a test
 ----------
 

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ This will install the package but you can still edit it and you don't need the p
 Logging
 -------
 
-By default, :code:`cdm_reader_mapper` outputs logging information to :code:`STDOUT`. To tell :code:`cdm_reader_mapper` to output logs to a file, set the :code:`CDM_LOG_FILE` environment variable **before** loading :code:`cdm_reader_mapper`.
+By default, :code:`cdm_reader_mapper` outputs logging information to :code:`stdout`. To tell :code:`cdm_reader_mapper` to output logs to a file, set the :code:`CDM_LOG_FILE` environment variable **before** loading :code:`cdm_reader_mapper`.
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -56,7 +56,7 @@ By default, :code:`cdm_reader_mapper` outputs logging information to :code:`stdo
    import os
    os.environ['CDM_LOG_FILE'] = 'log_file.log'
 
-   import cdm_reader_mapper as cmd
+   import cdm_reader_mapper as cdm
 
 This will set the file :code:`log_file.log` as the output for all logging information from :code:`cdm_reader_mapper`, including the initial logging on loading of the package.
 

--- a/cdm_reader_mapper/common/logging_hdlr.py
+++ b/cdm_reader_mapper/common/logging_hdlr.py
@@ -9,9 +9,11 @@ Created on Wed Apr  3 08:45:03 2019
 from __future__ import annotations
 
 import logging
+import os
+LOG_FN = os.getenv('CDM_LOG_FILE', None)
 
 
-def init_logger(module, level="INFO", fn=None):
+def init_logger(module, level="INFO", fn=LOG_FN):
     """Initialize logger."""
     from importlib import reload
 


### PR DESCRIPTION
`cdm_reader_mapper` only logs out information to stdout, sometimes it is preferable to output logs to a file instead.

This is a simple solution that adds a check for an environmental variable `CDM_LOG_FILE`, if that is set then `cdm_reader_mapper` will output logs to that file. Default behaviour of the `logging` module is `filemode='a'`, so logs are appended to this file. If this environment variable is not set then logs are sent to stdout.

The user can either set this variable in the shell before loading python, or in their script with

```py
import os
os.environ['CDM_LOG_FILE'] = 'logfile.log'
```

I added these instructions to the readme.

There are a number of calls to `common.logging_hdlr.init_logger` which resets the logging config on each call which will overwrite a user's own logging config. An alternative approach would be to check if a logging config already exists and use this existing configuration. I wasn't able to identify a simple way to differentiate between a user's config and the default config set-up by `logging`. 

The environment variable approach is hence a compromise that allows for `cdm_reader_mapper` to reset the logging config - a cursory search suggests this is to allow for changing of the logging level in different functions.