### PR TITLE
Remove snappy

### DIFF
--- a/ci/requirements/docs.yml
+++ b/ci/requirements/docs.yml
@@ -16,7 +16,6 @@ dependencies:
     - h5netcdf
     - pyarrow
     # https://github.com/openforcefield/openff-nagl/issues/106
-    - snappy<1.2
     #documentation
     - ipython
     - nbsphinx

--- a/ci/requirements/environment.yml
+++ b/ci/requirements/environment.yml
@@ -15,7 +15,6 @@ dependencies:
     - datashader
     - pyarrow
     # https://github.com/openforcefield/openff-nagl/issues/106
-    - snappy<1.2
     # for testing
     - pytest
     - pytest-cov

--- a/ci/requirements/requirements.txt
+++ b/ci/requirements/requirements.txt
@@ -14,4 +14,3 @@ textdistance
 swifter
 platformdirs
 pyarrow
-snappy<1.2


### PR DESCRIPTION
cdm_reader_mapper fails to install using pip - difference in `snappy` packages between conda and pip.

See #33