### PR TITLE
Build ``cdm_reader_mapper`` consistent to ``pandas``

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,19 +16,28 @@ New features and enhancements
   * `mode` == "data"; calls ``cdm_reader_mapper.read_data`` or ``cdm_reader_mapper.write_data``
   * `mode` == "tables"; calls ``cdm_reader_mapper.read_tables`` or ``cdm_reader_mapper.write_tables``
 
-* optionally, call ``cdm_reader_mapper.read_tables`` with either source file or source directory path (:pull:`238`)
+* optionally, call ``cdm_reader_mapper.read_tables`` with either source file or source directory path (:pull:`238`).
+
+* apply attribute to ``DataBundle.data`` if attribute is nor defined in ``DataBundle`` (:pull:`248`).
+* apply pandas functions directly to ``DataBundle.data`` by calling ``DataBundle.<pandas-func>`` (:pull:`248`).
+* make ``DataBundle`` support item assignment for ``DataBundle.data`` (:pull:`248`).
+* optionally, apply selections to ``DataBundle.mask`` in ``DataBundle.select_*`` functions (:pull:`248`).
+
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
 
 * remove property ``tables`` from ``DataBundle`` object. Instead, ``DataBundle.map_model`` overwrites ``.DataBundle.data`` (:pull:`238`).
-* set default ``overwrite`` values from ``True`` to ``False`` that is consistent with pandas ``in_place`` argument (:pull:`238`).
+* set default ``overwrite`` values from ``True`` to ``False`` that is consistent with pandas ``inplace`` argument and rename ``overwrite`` to ``inplace`` (:pull:`238`, :pull:`248`).
+* ``DataBundle`` method functions return a ``DataBundle`` instead of a ``pandas.DataFrame`` (:pull:`248`).
+* ``DataBundle.select_*`` functions write only selected entries to ``DataBundle.data`` and do not take other list entries from ``common.select_*`` function returns into account (:pull:`248`).
 
 Bug fixes
 ^^^^^^^^^
 
 * ``cdm_reder_mapper.metmetpy``: set deck keys from ``???`` to ``d???`` in icoads json files which makes values accessible again (:pull:`238`).
 * ``cdm_reder_mapper.metmetpy``: set ``imma1`` to ``icoads`` and ``immt`` to ``gcc`` in icoads/gcc json files which makes properties accessible again (:pull:`238`).
+* ``DataBundle.copy`` function now makes a real deepcopy of ``DataBundle`` object (:pull:`248`).
 
 2.0.1 (2025-02-25)
 ------------------

--- a/cdm_reader_mapper/common/select.py
+++ b/cdm_reader_mapper/common/select.py
@@ -18,10 +18,10 @@ from cdm_reader_mapper.common import pandas_TextParser_hdlr
 # the dataframe_apply_index(), because they are all the same but for the
 # selection applied!!!!!
 
-#    The index of the resulting dataframe(s) is reinitialized here, it does not
-#    inherit from parent df
+# The index of the resulting dataframe(s) is reinitialized here, it does not
+# inherit from parent df
 #
-#    data is a dataframe or a TextFileReader
+# data is a dataframe or a TextFileReader
 
 
 def dataframe_apply_index(
@@ -50,7 +50,7 @@ def dataframe_apply_index(
 def select_true(data, mask, out_rejected=False, in_index=False):
     """DOCUMENTATION."""
 
-    #   mask is a the full df/parser of which we only use col
+    # mask is a the full df/parser of which we only use col
     def dataframe(
         df, mask, out_rejected=False, in_index=False, idx_in_offset=0, idx_out_offset=0
     ):
@@ -125,7 +125,7 @@ def select_true(data, mask, out_rejected=False, in_index=False):
 def select_from_list(data, selection, out_rejected=False, in_index=False):
     """DOCUMENTATION."""
 
-    #   selection is a dictionary like {col_name:[values to select]}
+    # selection is a dictionary like {col_name:[values to select]}
     def dataframe(
         df,
         col,

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -300,12 +300,12 @@ class DataBundle:
         """
         return deepcopy(self)
 
-    def select_true(self, overwrite=False, **kwargs):
+    def select_true(self, inplace=False, **kwargs):
         """Select valid values from :py:attr:`data` via :py:attr:`mask`.
 
         Parameters
         ----------
-        overwrite: bool
+        inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return list containing both DataFrame with true and DataFrame with invalid rows.
             Default: False
@@ -318,7 +318,7 @@ class DataBundle:
 
         Select valid values only with overwriting the old data.
 
-        >>> db.select_true(overwrite=True)
+        >>> db.select_true(inplace=True)
         >>> true_values = db.data
 
         See Also
@@ -331,12 +331,12 @@ class DataBundle:
         For more information see :py:func:`select_true`
         """
         selected = select_true(self._data, self._mask, **kwargs)
-        if overwrite is True:
+        if inplace is True:
             self._data = selected[0]
             return self
         return selected
 
-    def select_from_list(self, selection, overwrite=False, **kwargs):
+    def select_from_list(self, selection, inplace=False, **kwargs):
         """Select columns from :py:attr:`data` with specific values.
 
         Parameters
@@ -344,7 +344,7 @@ class DataBundle:
         selection: dict
             Keys: columns to be selected.
             Values: values in keys to be selected
-        overwrite: bool
+        inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return list containing both DataFrame with true and DataFrame with invalid entries.
             Default: False
@@ -359,7 +359,7 @@ class DataBundle:
 
         Select specific columns with overwriting the old data.
 
-        >>> db.select_from_list(selection={("c1", "B1"): [26, 41]}, overwrite=True)
+        >>> db.select_from_list(selection={("c1", "B1"): [26, 41]}, inplace=True)
         >>> true_values = db.selected
 
         See Also
@@ -372,19 +372,19 @@ class DataBundle:
         For more information see :py:func:`select_from_list`
         """
         selected = select_from_list(self._data, selection, **kwargs)
-        if overwrite is True:
+        if inplace is True:
             self._data = selected[0]
             return self
         return selected
 
-    def select_from_index(self, index, overwrite=False, **kwargs):
+    def select_from_index(self, index, inplace=False, **kwargs):
         """Select rows of :py:attr:`data` with specific indexes.
 
         Parameters
         ----------
         index: list
             Indexes to be selected.
-        overwrite: bool
+        inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return list containing both DataFrame with true and DataFrame with invalid entries.
             Default: False
@@ -397,7 +397,7 @@ class DataBundle:
 
         Select specific columns with overwriting the old data.
 
-        >>> db.select_from_index(index=[0, 2, 4], overwrite=True)
+        >>> db.select_from_index(index=[0, 2, 4], inplace=True)
         >>> true_values = db.selected
 
         See Also
@@ -410,7 +410,7 @@ class DataBundle:
         For more information see :py:func:`select_from_index`
         """
         selected = select_from_index(self._data, index, **kwargs)
-        if overwrite is True:
+        if inplace is True:
             self._data = selected[0]
             return self
         return selected
@@ -433,15 +433,15 @@ class DataBundle:
         """
         return count_by_cat(self._data, **kwargs)
 
-    def replace_columns(self, df_corr, overwrite=False, **kwargs):
+    def replace_columns(self, df_corr, inplace=False, **kwargs):
         """Replace columns in :py:attr:`data`.
 
         Parameters
         ----------
         df_corr: pandas.DataFrame
             Data to be inplaced.
-        overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in :py:class:`cdm_reader_mapper.DataBundle`
+        inplace: bool
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return pd.DataFrame with replaced columns.
             Default: False
 
@@ -456,18 +456,18 @@ class DataBundle:
         For more information see :py:func:`replace_columns`
         """
         _data = replace_columns(df_l=self._data, df_r=df_corr, **kwargs)
-        if overwrite is True:
+        if inplace is True:
             self._data = _data
             self._columns = self._data.columns
             return self
         return _data
 
-    def correct_datetime(self, overwrite=False):
+    def correct_datetime(self, inplace=False):
         """Correct datetime information in :py:attr:`data`.
 
         Parameters
         ----------
-        overwrite: bool
+        inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return datetime-corretcted DataFrame.
             Default: False
@@ -487,7 +487,7 @@ class DataBundle:
         For more information see :py:func:`correct_datetime`
         """
         _data = correct_datetime(self._data, self._imodel)
-        if overwrite is True:
+        if inplace is True:
             self._data = _data
             return self
         return _data
@@ -518,12 +518,12 @@ class DataBundle:
         """
         return validate_datetime(self._data, self._imodel)
 
-    def correct_pt(self, overwrite=False):
+    def correct_pt(self, inplace=False):
         """Correct platform type information in :py:attr:`data`.
 
         Parameters
         ----------
-        overwrite: bool
+        inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return platform-corretcted DataFrame.
             Default: False
@@ -543,7 +543,7 @@ class DataBundle:
         For more information see :py:func:`correct_pt`
         """
         _data = correct_pt(self._data, self._imodel)
-        if overwrite is True:
+        if inplace is True:
             self._data = _data
             return self
         return _data
@@ -574,14 +574,14 @@ class DataBundle:
         """
         return validate_id(self._data, self._imodel, **kwargs)
 
-    def map_model(self, overwrite=False, **kwargs):
+    def map_model(self, inplace=False, **kwargs):
         """Map :py:attr:`data` to the Common Data Model.
         Write output to :py:attr:`data`.
 
         Parameters
         ----------
-        overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in :py:class:`cdm_reader_mapper.DataBundle`
+        inplace: bool
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return CDM tables.
             Default: False
 
@@ -594,7 +594,7 @@ class DataBundle:
         For more information see :py:func:`map_model`
         """
         _tables = map_model(self._data, self._imodel, **kwargs)
-        if overwrite is True:
+        if inplace is True:
             self._mode = "tables"
             self.columns = _tables.columns
             self._data = _tables
@@ -667,13 +667,13 @@ class DataBundle:
         self.DupDetect = duplicate_check(data, **kwargs)
         return self
 
-    def flag_duplicates(self, overwrite=False, **kwargs):
+    def flag_duplicates(self, inplace=False, **kwargs):
         """Flag detected duplicates in :py:attr:`data`.
 
         Parameters
         ----------
-        overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in DataBundle
+        inplace: bool
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return DataFrame containing flagged duplicates.
             Default: False
 
@@ -689,7 +689,7 @@ class DataBundle:
 
         Flag duplicates with overwriting :py:attr:`data`.
 
-        >>> db.flag_duplicates(overwrite=True)
+        >>> db.flag_duplicates(inplace=True)
         >>> flagged_tables = db.data
 
         See Also
@@ -708,7 +708,7 @@ class DataBundle:
             df_["header"] = self.DupDetect.result
         else:
             df_ = self.DupDetect.result
-        if overwrite is True:
+        if inplace is True:
             self._data = df_
             return self
         return df_
@@ -741,13 +741,13 @@ class DataBundle:
         """
         return self.DupDetect.get_duplicates(**kwargs)
 
-    def remove_duplicates(self, overwrite=False, **kwargs):
+    def remove_duplicates(self, inplace=False, **kwargs):
         """Remove detected duplicates in :py:attr:`data`.
 
         Parameters
         ----------
-        overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in :py:class:`cdm_reader_mapper.DataBundle`
+        inplace: bool
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return DataFrame containing non-duplicate rows.
             Default: False
 
@@ -763,7 +763,7 @@ class DataBundle:
 
         Remove duplicates with overwriting :py:attr:`data`.
 
-        >>> db.remove_duplicates(overwrite=True)
+        >>> db.remove_duplicates(inplace=True)
         >>> removed_tables = db.data
 
         See Also
@@ -780,7 +780,7 @@ class DataBundle:
         df_ = self._data.copy()
         header_ = self.DupDetect.result
         df_ = df_[df_.index.isin(header_.index)]
-        if overwrite is True:
+        if inplace is True:
             self._data = df_
             return self
         return df_

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -211,7 +211,7 @@ class DataBundle:
             setattr(self, f"_{name}", data)
         return self
 
-    def stack_v(self, other, datasets=["data", "mask", "tables"], **kwargs):
+    def stack_v(self, other, datasets=["data", "mask"], **kwargs):
         """Stack multiple :py:class:`~DataBundle`'s vertically.
 
         Parameters
@@ -252,7 +252,7 @@ class DataBundle:
             setattr(self, data, self_data.reset_index(drop=True))
         return self
 
-    def stack_h(self, other, datasets=["data", "mask", "tables"], **kwargs):
+    def stack_h(self, other, datasets=["data", "mask"], **kwargs):
         """Stack multiple :py:class:`~DataBundle`'s horizontally.
 
         Parameters
@@ -260,7 +260,7 @@ class DataBundle:
         other: str, list
             List of other :py:class:`~DataBundle` to stack horizontally.
         datasets: str, list
-            List of datasets to be stacked
+            List of datasets to be stacked.
             Default: ['data', 'mask']
 
         Note

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -48,12 +48,12 @@ class DataBundle:
 
     Examples
     --------
-    Getting a :py:class:`cdm_reader_mapper.DataBundle` while reading data from disk.
+    Getting a :py:class:`~DataBundle` while reading data from disk.
 
     >>> from cdm_reader_mapper import read_mdf
     >>> db = read_mdf(source="file_on_disk", imodel="custom_model_name")
 
-    Constructing a :py:class:`cdm_reader_mapper.DataBundle` from already read MDf data.
+    Constructing a :py:class:`~DataBundle` from already read MDf data.
 
     >>> from cdm_reader_mapper import DataBundle
     >>> read = read_mdf(source="file_on_disk", imodel="custom_model_name")
@@ -61,7 +61,7 @@ class DataBundle:
     >>> mask_ = read.mask
     >>> db = DataBundle(data=data_, mask=mask_)
 
-    Constructing a :py:class:`cdm_reader_mapper.DataBundle` from already read CDM data.
+    Constructing a :py:class:`~DataBundle` from already read CDM data.
 
     >>> from cdm_reader_mapper import read_tables
     >>> tables = read_tables("path_to_files")
@@ -92,6 +92,59 @@ class DataBundle:
         """Length of :py:attr:`data`."""
         return get_length(self.data)
 
+    # def __getattr__(self, name):
+    #    def method(data="data", overwrite=True, *args, **kwargs):
+    #        print(name, data, overwrite, args, kwargs)
+    #    return method
+
+    def __getattr__(self, attr):
+        """Apply attribute to :py:attr:`data`, :py:attr:`mask` or :py:attr:`tables` if attribute is not defined for :py:class:`~DataBundle` ."""
+
+        def method(*args, **kwargs):
+            print(attr, args, kwargs)
+            # def method(*args, **kwargs):
+            print(attr)
+            _data = f"_{data}"
+            print(data)
+            print(overwrite)
+            if not hasattr(self, _data):
+                raise NameError(
+                    f"name {data} is not defined. Use one of [data, tables, mask]."
+                )
+            _name = getattr(self, data)
+            attr = getattr(_name, attr)
+            if not callable(attr):
+                return attr
+            _data = attr(*args, **kwargs)
+            print(_data)
+            print(overwrite)
+            if overwrite is True:
+                setattr(self, "_data", _data)
+                return self
+            return _data
+
+        # if attr.startswith("__") and attr.endswith("__"):
+        #    raise AttributeError(f"DataBundle object has no attribute {attr}.")
+        # _data = f"_{data}"
+        # if not hasattr(self, _data):
+        #    raise NameError(
+        #        f"name {data} is not defined. Use one of [data, tables, mask]."
+        #    )
+
+        return method
+
+        _name = getattr(self, _data)
+        attr = getattr(_name, attr)
+        if not callable(attr):
+            return attr
+        _data = attr(*args, **kwargs)
+        print(_data)
+        print(overwrite)
+        if overwrite is True:
+            setattr(self, "_data", _data)
+            return self
+        return _data
+
     def __getitem__(self, item):
         """Make class subscriptable."""
         return getattr(self, item)
@@ -112,7 +165,7 @@ class DataBundle:
     @property
     def columns(self):
         """Column labels of :py:attr:`data`."""
-        return self._return_property("_columns")
+        return self._data.columns
 
     @property
     def dtypes(self):
@@ -172,7 +225,7 @@ class DataBundle:
         Parameters
         ----------
         addition: dict
-             Additional elements to add to the :py:class:`cdm_reader_mapper.DataBundle`.
+             Additional elements to add to the :py:class:`~DataBundle`.
 
         Examples
         --------
@@ -184,7 +237,7 @@ class DataBundle:
         return self
 
     def stack_v(self, other, datasets=["data", "mask", "tables"], **kwargs):
-        """Stack multiple :py:class:`cdm_reader_mapper.DataBundle`'s vertically.
+        """Stack multiple :py:class:`~DataBundle`'s vertically.
 
         Parameters
         ----------
@@ -196,7 +249,7 @@ class DataBundle:
 
         Note
         ----
-        The DataFrames in the :py:class:`cdm_reader_mapper.DataBundle` have to have the same data columns!
+        The DataFrames in the :py:class:`~DataBundle` have to have the same data columns!
 
         Examples
         --------
@@ -225,19 +278,19 @@ class DataBundle:
         return self
 
     def stack_h(self, other, datasets=["data", "mask", "tables"], **kwargs):
-        """Stack multiple :py:class:`cdm_reader_mapper.DataBundle`'s horizontally.
+        """Stack multiple :py:class:`~DataBundle`'s horizontally.
 
         Parameters
         ----------
         other: str, list
-            List of other :py:class:`cdm_reader_mapper.DataBundle` to stack horizontally.
+            List of other :py:class:`~DataBundle` to stack horizontally.
         datasets: str, list
             List of datasets to be stacked
             Default: ['data', 'mask', 'tables']
 
         Note
         ----
-        The DataFrames in the :py:class:`cdm_reader_mapper.DataBundle` may have different data columns!
+        The DataFrames in the :py:class:`~DataBundle` may have different data columns!
 
         Examples
         --------
@@ -264,7 +317,7 @@ class DataBundle:
         return self
 
     def copy(self):
-        """Make deep copy of a :py:class:`cdm_reader_mapper.DataBundle`.
+        """Make deep copy of a :py:class:`~DataBundle`.
 
         Examples
         --------
@@ -278,7 +331,7 @@ class DataBundle:
         Parameters
         ----------
         overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in :py:class:`cdm_reader_mapper.DataBundle`
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return list containing both DataFrame with true and DataFrame with invalid rows.
             Default: True
 
@@ -321,7 +374,7 @@ class DataBundle:
             Keys: columns to be selected.
             Values: values in keys to be selected
         overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in :py:class:`cdm_reader_mapper.DataBundle`
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return list containing both DataFrame with true and DataFrame with invalid entries.
             Default: True
 
@@ -365,7 +418,7 @@ class DataBundle:
         index: list
             Indexes to be selected.
         overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in :py:class:`cdm_reader_mapper.DataBundle`
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return list containing both DataFrame with true and DataFrame with invalid entries.
             Default: True
 
@@ -445,7 +498,7 @@ class DataBundle:
         Parameters
         ----------
         overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in :py:class:`cdm_reader_mapper.DataBundle`
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return datetime-corretcted DataFrame.
             Default: True
 
@@ -501,7 +554,7 @@ class DataBundle:
         Parameters
         ----------
         overwrite: bool
-            If ``True`` overwrite :py:attr:`data` in :py:class:`cdm_reader_mapper.DataBundle`
+            If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
             else return platform-corretcted DataFrame.
             Default: True
 
@@ -597,7 +650,7 @@ class DataBundle:
 
         Note
         ----
-        Before writing CDM tables on disk, they have to be provided in :py:class:`cdm_reader_mapper.DataBundle`,
+        Before writing CDM tables on disk, they have to be provided in :py:class:`~DataBundle`,
         e.g. with :py:func:`DataBundle.map_model`.
 
         Examples
@@ -621,7 +674,7 @@ class DataBundle:
 
         Note
         ----
-        Before processing the duplicate check, CDM tables have to be provided in :py:class:`cdm_reader_mapper.DataBundle`,
+        Before processing the duplicate check, CDM tables have to be provided in :py:class:`~DataBundle`,
         e.g. with :py:func:`DataBundle.map_model`.
 
         Examples
@@ -718,7 +771,7 @@ class DataBundle:
         Parameters
         ----------
         overwrite: bool
-            If ``True`` overwrite :py:attr:`tables` in :py:class:`cdm_reader_mapper.DataBundle`
+            If ``True`` overwrite :py:attr:`tables` in :py:class:`~DataBundle`
             else return DataFrame containing non-duplicate rows.
             Default: True
 

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -111,7 +111,7 @@ class DataBundle:
             try:
                 return attr(*args, **kwargs)
             except TypeError:
-                return attr[*args]
+                return attr[args]
             except Exception:
                 raise ValueError(f"{attr} is neither callable nor subscriptable.")
 

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -241,7 +241,7 @@ class DataBundle:
         Examples
         --------
         >>> tables = read_tables("path_to_files")
-        >>> db = db.add({"tables": tables})
+        >>> db = db.add({"data": tables})
         """
         for name, data in addition.items():
             setattr(self, f"_{name}", data)
@@ -473,11 +473,9 @@ class DataBundle:
         """
         _data = self._data.copy()
         if subset is not None:
-            _data[subset] = replace_columns(
-                df_l=self._data[subset], df_r=df_corr, **kwargs
-            )
+            _data[subset] = replace_columns(df_l=_data[subset], df_r=df_corr, **kwargs)
         else:
-            _data = replace_columns(df_l=self._data, df_r=df_corr, **kwargs)
+            _data = replace_columns(df_l=_data, df_r=df_corr, **kwargs)
 
         if inplace is True:
             self._data = _data
@@ -486,6 +484,7 @@ class DataBundle:
 
         db = self.copy()
         db._data = _data
+        db._columns = _data.columns
         return db
 
     def correct_datetime(self, inplace=False):

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -112,9 +112,9 @@ class DataBundle:
 
         return method
 
-    def __print__(self):
-        """Print :py:attr:`data`."""
-        print(self._data)
+    def __repr__(self):
+        """Return a string representation for :py:attr:`data`."""
+        return self._data.__repr__()
 
     def __getitem__(self, item):
         """Make class subscriptable."""

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -145,7 +145,7 @@ class DataBundle:
             setattr(self, "_data", _data)
             return self
         return _data
-     
+
     def __print__(self):
         """Print :py:attr:`data`."""
         print(self.data)

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -277,7 +277,7 @@ class DataBundle:
             Default: ['data', 'mask']
         inplace: bool
             If ``True`` overwrite datasets in :py:class:`~DataBundle`
-            else return stacked datasets.
+            else return a copy of :py:class:`~DataBundle` with stacked datasets.
             Default: False
 
         Note
@@ -306,7 +306,7 @@ class DataBundle:
             Default: ['data', 'mask']
         inplace: bool
             If ``True`` overwrite `datasets` in :py:class:`~DataBundle`
-            else return stacked datasets.
+            else return a copy of :py:class:`~DataBundle` with stacked datasets.
             Default: False
 
         Note
@@ -341,14 +341,17 @@ class DataBundle:
             setattr(db, key, value)
         return db
 
-    def select_true(self, inplace=False, **kwargs):
+    def select_true(self, mask=False, inplace=False, **kwargs):
         """Select valid values from :py:attr:`data` via :py:attr:`mask`.
 
         Parameters
         ----------
+        mask: bool
+            If ``True`` select also valid values from :py:attr:`mask`
+            Default: False
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return list containing both DataFrame with true and DataFrame with invalid rows.
+            else return a copy of :py:class:`~DataBundle` with valid values only in :py:attr:`data`.
             Default: False
 
         Examples
@@ -371,13 +374,14 @@ class DataBundle:
         ----
         For more information see :py:func:`select_true`
         """
-        selected = select_true(self._data, self._mask, **kwargs)
-        if inplace is True:
-            self._data = selected[0]
-            return self
-        return selected
+        db_ = self._get_db(inplace)
+        selected = select_true(db_._data, db_._mask, **kwargs)
+        db_._data = selected[0]
+        if mask is True:
+            db_._mask = select_from_index(db_._mask, db_.index, **kwargs)
+        return db_
 
-    def select_from_list(self, selection, inplace=False, **kwargs):
+    def select_from_list(self, selection, mask=False, inplace=False, **kwargs):
         """Select columns from :py:attr:`data` with specific values.
 
         Parameters
@@ -385,9 +389,12 @@ class DataBundle:
         selection: dict
             Keys: columns to be selected.
             Values: values in keys to be selected
+        mask: bool
+            If ``True`` select also valid values from :py:attr:`mask`
+            Default: False
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return list containing both DataFrame with true and DataFrame with invalid entries.
+            else return a copy of :py:class:`~DataBundle` with selected columns only in :py:attr:`data`.
             Default: False
 
         Examples
@@ -412,22 +419,26 @@ class DataBundle:
         ----
         For more information see :py:func:`select_from_list`
         """
-        selected = select_from_list(self._data, selection, **kwargs)
-        if inplace is True:
-            self._data = selected[0]
-            return self
-        return selected
+        db_ = self._get_db(inplace)
+        selected = select_from_list(db_._data, selection, **kwargs)
+        db_._data = selected[0]
+        if mask is True:
+            db_._mask = select_from_index(db_._mask, db_.index, **kwargs)
+        return db_
 
-    def select_from_index(self, index, inplace=False, **kwargs):
+    def select_from_index(self, index, mask=False, inplace=False, **kwargs):
         """Select rows of :py:attr:`data` with specific indexes.
 
         Parameters
         ----------
         index: list
             Indexes to be selected.
+        mask: bool
+            If ``True`` select also valid values from :py:attr:`mask`
+            Default: False
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return list containing both DataFrame with true and DataFrame with invalid entries.
+            else return a copy of :py:class:`~DataBundle` with selected rows only in :py:attr:`data`.
             Default: False
 
         Examples
@@ -450,11 +461,12 @@ class DataBundle:
         ----
         For more information see :py:func:`select_from_index`
         """
-        selected = select_from_index(self._data, index, **kwargs)
-        if inplace is True:
-            self._data = selected[0]
-            return self
-        return selected
+        db_ = self._get_db(inplace)
+        selected = select_from_index(db_._data, index, **kwargs)
+        db_._data = selected[0]
+        if mask is True:
+            db_._mask = select_from_index(db_._mask, index, **kwargs)
+        return db_
 
     def unique(self, **kwargs):
         """Get unique values of :py:attr:`data`.
@@ -485,7 +497,7 @@ class DataBundle:
             Select subset by columns. This option is useful for multi-indexed :py:attr:`data`.
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return pd.DataFrame with replaced columns.
+            else return a copy of :py:class:`~DataBundle` with replaced column names in :py:attr:`data`.
             Default: False
 
         Examples
@@ -515,7 +527,7 @@ class DataBundle:
         ----------
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return datetime-corretcted DataFrame.
+            else return a copy of :py:class:`~DataBundle` with datetime-corrected values in :py:attr:`data`.
             Default: False
 
         Examples
@@ -569,7 +581,7 @@ class DataBundle:
         ----------
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return platform-corretcted DataFrame.
+            else return a copy of :py:class:`~DataBundle` with platform-corrected values in :py:attr:`data`.
             Default: False
 
         Examples
@@ -624,7 +636,7 @@ class DataBundle:
         ----------
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return CDM tables.
+            else return a copy of :py:class:`~DataBundle` with :py:attr:`data` as CDM tables.
             Default: False
 
         Examples
@@ -715,7 +727,7 @@ class DataBundle:
         ----------
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return DataFrame containing flagged duplicates.
+            else return a copy of :py:class:`~DataBundle` with :py:attr:`data` containing flagged duplicates.
             Default: False
 
         Note
@@ -786,7 +798,7 @@ class DataBundle:
         ----------
         inplace: bool
             If ``True`` overwrite :py:attr:`data` in :py:class:`~DataBundle`
-            else return DataFrame containing non-duplicate rows.
+            else return a copy of :py:class:`~DataBundle` with :py:attr:`data` containing no duplicates.
             Default: False
 
         Note

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -108,7 +108,12 @@ class DataBundle:
                 return self.func(*args, **kwargs)
 
         def method(*args, **kwargs):
-            return attr(*args, **kwargs)
+            try:
+                return attr(*args, **kwargs)
+            except TypeError:
+                return attr[*args]
+            except Exception:
+                raise ValueError(f"{attr} is neither callable nor subscriptable.")
 
         if attr.startswith("__") and attr.endswith("__"):
             raise AttributeError(f"DataBundle object has no attribute {attr}.")

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -93,62 +93,27 @@ class DataBundle:
         """Length of :py:attr:`data`."""
         return get_length(self.data)
 
-    # def __getattr__(self, name):
-    #    def method(data="data", overwrite=True, *args, **kwargs):
-    #        print(name, data, overwrite, args, kwargs)
-    #    return method
-
     def __getattr__(self, attr):
-        """Apply attribute to :py:attr:`data`, :py:attr:`mask` or :py:attr:`tables` if attribute is not defined for :py:class:`~DataBundle` ."""
+        """Apply attribute to :py:attr:`data` if attribute is not defined for :py:class:`~DataBundle` ."""
 
         def method(*args, **kwargs):
-            print(attr, args, kwargs)
-            # def method(*args, **kwargs):
-            print(attr)
-            _data = f"_{data}"
-            print(data)
-            print(overwrite)
-            if not hasattr(self, _data):
-                raise NameError(
-                    f"name {data} is not defined. Use one of [data, tables, mask]."
-                )
-            _name = getattr(self, data)
-            attr = getattr(_name, attr)
-            if not callable(attr):
-                return attr
-            _data = attr(*args, **kwargs)
-            print(_data)
-            print(overwrite)
-            if overwrite is True:
-                setattr(self, "_data", _data)
-                return self
-            return _data
+            return attr(*args, **kwargs)
 
-        # if attr.startswith("__") and attr.endswith("__"):
-        #    raise AttributeError(f"DataBundle object has no attribute {attr}.")
-        # _data = f"_{data}"
-        # if not hasattr(self, _data):
-        #    raise NameError(
-        #        f"name {data} is not defined. Use one of [data, tables, mask]."
-        #    )
+        if attr.startswith("__") and attr.endswith("__"):
+            raise AttributeError(f"DataBundle object has no attribute {attr}.")
 
-        return method
-
-        _name = getattr(self, _data)
-        attr = getattr(_name, attr)
+        _data = "_data"
+        if not hasattr(self, _data):
+            raise NameError("'data' is not defined in DataBundle object.")
+        _df = getattr(self, _data)
+        attr = getattr(_df, attr)
         if not callable(attr):
             return attr
-        _data = attr(*args, **kwargs)
-        print(_data)
-        print(overwrite)
-        if overwrite is True:
-            setattr(self, "_data", _data)
-            return self
-        return _data
-     
+        return method
+
     def __print__(self):
         """Print :py:attr:`data`."""
-        print(self.data)
+        print(self._data)
 
     def __getitem__(self, item):
         """Make class subscriptable."""

--- a/docs/tool-overview-databundle.rst
+++ b/docs/tool-overview-databundle.rst
@@ -75,11 +75,11 @@ Now the meteorological data can be maqpped to the Common Data Model (CDM_) using
 
     cdm_tables = db.map_model()
 
-.. note:: Set ``overwrite`` to True to overwrite :py:attr:`DataBundle.data`:
+.. note:: Set ``inplace`` to True to overwrite :py:attr:`DataBundle.data`:
 
 .. code-block:: console
 
-   db.map_model(overwrite=True)
+   db.map_model(inplace=True)
 
    cdm_tables = db.data
 

--- a/docs/tool-overview-mapper.rst
+++ b/docs/tool-overview-mapper.rst
@@ -25,11 +25,11 @@ Workflow
 
    cdm_tables = db.map_model()
 
-.. note:: Set ``overwrite`` to True to overwrite :py:attr:`DataBundle.data`:
+.. note:: Set ``inplace`` to True to overwrite :py:attr:`DataBundle.data`:
 
 .. code-block:: console
 
-   db.map_model(overwrite=True)
+   db.map_model(inplace=True)
 
    cdm_tables = db.data
 

--- a/tests/_testing_workflow_suite.py
+++ b/tests/_testing_workflow_suite.py
@@ -33,8 +33,8 @@ def _testing_suite(
         **kwargs,
     )
 
-    db_mdf.correct_datetime(overwrite=True)
-    db_mdf.correct_pt(overwrite=True)
+    db_mdf.correct_datetime(inplace=True)
+    db_mdf.correct_pt(inplace=True)
 
     val_dt = db_mdf.validate_datetime()
 
@@ -100,7 +100,7 @@ def _testing_suite(
         cdm_subset=cdm_subset,
         codes_subset=codes_subset,
         log_level="DEBUG",
-        overwrite=True,
+        inplace=True,
     )
 
     col_subset = get_col_subset(db_mdf.data, codes_subset)

--- a/tests/test_databundle.py
+++ b/tests/test_databundle.py
@@ -68,3 +68,7 @@ def test_stack_h(test_data):
     orig_data = data["data_700"].copy()
     test_data = update_columns(test_data)
     orig_data.stack_h(test_data, datasets=["data"])
+
+
+def test_print():
+    print(data["data_703"])

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -111,7 +111,7 @@ def test_duplicates_remove():
 
 def test_duplicates_craid():
     cdm_craid.duplicate_check(ignore_columns="primary_station_id")
-    cdm_craid.flag_duplicates(overwrite=True)
+    cdm_craid.flag_duplicates(inplace=True)
     tables = cdm_craid.data.copy()
     result = tables["header"]
     assert_array_equal(result["duplicate_status"], [0] * 10)

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -112,8 +112,6 @@ def test_duplicates_remove():
 def test_duplicates_craid():
     cdm_craid.duplicate_check(ignore_columns="primary_station_id")
     cdm_craid.flag_duplicates(inplace=True)
-    tables = cdm_craid.data.copy()
-    result = tables["header"]
-    assert_array_equal(result["duplicate_status"], [0] * 10)
-    assert_array_equal(result["report_quality"], [2] * 10)
-    assert_array_equal(result["duplicates"], ["null"] * 10)
+    assert_array_equal(cdm_craid[("header", "duplicate_status")], [0] * 10)
+    assert_array_equal(cdm_craid[("header", "report_quality")], [2] * 10)
+    assert_array_equal(cdm_craid[("header", "duplicates")], ["null"] * 10)

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -104,8 +104,8 @@ def test_duplicates_remove():
             "station_course": "null",
         },
     )
-    tables_dups_removed = cdm_icoads.remove_duplicates()
-    expected = cdm_icoads.data[[0, 1, 2, 4, 6, 8, 10, 12, 15, 17, 18]]
+    tables_dups_removed = cdm_icoads.remove_duplicates().data
+    expected = cdm_icoads.iloc[[0, 1, 2, 4, 6, 8, 10, 12, 15, 17, 18]]
     assert_frame_equal(expected, tables_dups_removed)
 
 

--- a/tests/test_duplicates.py
+++ b/tests/test_duplicates.py
@@ -105,7 +105,7 @@ def test_duplicates_remove():
         },
     )
     tables_dups_removed = cdm_icoads.remove_duplicates()
-    expected = cdm_icoads.data.iloc[[0, 1, 2, 4, 6, 8, 10, 12, 15, 17, 18]]
+    expected = cdm_icoads.data[[0, 1, 2, 4, 6, 8, 10, 12, 15, 17, 18]]
     assert_frame_equal(expected, tables_dups_removed)
 
 

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -96,4 +96,4 @@ def test_replace():
         "MASKSTID2",
         "MASKSTID2",
     ]
-    pd.testing.assert_frame_equal(cdm_header.data, result)
+    pd.testing.assert_frame_equal(cdm_header.data, result.data)

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -25,33 +25,31 @@ def _get_data(TextParser, **kwargs):
 def test_select_true(TextParser):
     data = _get_data(TextParser, sections=["c99_data"])
     result = data.select_true(out_rejected=True)
-    selected = result[0]
-    deselected = result[1]
+    expected = data.data
+    selected = result.data
 
     if TextParser is True:
-        data = make_copy(data).read()
+        expected = make_copy(expected).read()
         selected = make_copy(selected).read()
-        deselected = make_copy(deselected).read()
 
-    exp1 = data[:5].reset_index(drop=True)
-    exp2 = data[5:].reset_index(drop=True)
-    pd.testing.assert_frame_equal(exp1, selected)
-    pd.testing.assert_frame_equal(exp2, deselected)
+    expected = expected[:5].reset_index(drop=True)
+    pd.testing.assert_frame_equal(expected, selected)
 
 
 @pytest.mark.parametrize("TextParser", [False, True])
 def test_select_from_index(TextParser):
     data = _get_data(TextParser)
     result = data.select_from_index([0, 2, 4])
-    selected = result[0]
+    expected = data.data
+    selected = result.data
 
     if TextParser is True:
-        data = make_copy(data).read()
+        expected = make_copy(expected).read()
         selected = make_copy(selected).read()
 
-    idx = data.index.isin([0, 2, 4])
-    exp = data[idx].reset_index(drop=True)
-    pd.testing.assert_frame_equal(exp, selected)
+    idx = expected.index.isin([0, 2, 4])
+    expected = expected[idx].reset_index(drop=True)
+    pd.testing.assert_frame_equal(expected, selected)
 
 
 @pytest.mark.parametrize("TextParser", [True, False])
@@ -59,20 +57,16 @@ def test_select_from_list(TextParser):
     data = _get_data(TextParser)
     selection = {("c1", "B1"): [26, 41]}
     result = data.select_from_list(selection, out_rejected=True, in_index=True)
-    selected = result[0]
-    deselected = result[1]
+    expected = data.data
+    selected = result.data
 
     if TextParser is True:
-        data = make_copy(data).read()
+        expected = make_copy(expected).read()
         selected = make_copy(selected).read()
-        deselected = make_copy(deselected).read()
 
-    idx1 = data.index.isin([1, 3])
-    idx2 = data.index.isin([0, 2, 4])
-    exp1 = data[idx1].reset_index(drop=True)
-    exp2 = data[idx2].reset_index(drop=True)
-    pd.testing.assert_frame_equal(exp1, selected)
-    pd.testing.assert_frame_equal(exp2, deselected)
+    idx = expected.index.isin([1, 3])
+    expected = expected[idx].reset_index(drop=True)
+    pd.testing.assert_frame_equal(expected, selected)
 
 
 @pytest.mark.parametrize("TextParser", [True, False])

--- a/tests/test_operations.py
+++ b/tests/test_operations.py
@@ -4,7 +4,6 @@ import pandas as pd
 import pytest
 
 from cdm_reader_mapper import read, test_data
-from cdm_reader_mapper.common import replace_columns
 from cdm_reader_mapper.common.pandas_TextParser_hdlr import make_copy
 
 from ._results import cdm_header, correction_df
@@ -24,11 +23,10 @@ def _get_data(TextParser, **kwargs):
 
 @pytest.mark.parametrize("TextParser", [True, False])
 def test_select_true(TextParser):
-    read_ = _get_data(TextParser, sections=["c99_data"])
-    result = read_.select_true(out_rejected=True)
+    data = _get_data(TextParser, sections=["c99_data"])
+    result = data.select_true(out_rejected=True)
     selected = result[0]
     deselected = result[1]
-    data = read_.data
 
     if TextParser is True:
         data = make_copy(data).read()
@@ -43,9 +41,8 @@ def test_select_true(TextParser):
 
 @pytest.mark.parametrize("TextParser", [False, True])
 def test_select_from_index(TextParser):
-    read_ = _get_data(TextParser)
-    result = read_.select_from_index([0, 2, 4])
-    data = read_.data
+    data = _get_data(TextParser)
+    result = data.select_from_index([0, 2, 4])
     selected = result[0]
 
     if TextParser is True:
@@ -59,12 +56,11 @@ def test_select_from_index(TextParser):
 
 @pytest.mark.parametrize("TextParser", [True, False])
 def test_select_from_list(TextParser):
-    read_ = _get_data(TextParser)
+    data = _get_data(TextParser)
     selection = {("c1", "B1"): [26, 41]}
-    result = read_.select_from_list(selection, out_rejected=True, in_index=True)
+    result = data.select_from_list(selection, out_rejected=True, in_index=True)
     selected = result[0]
     deselected = result[1]
-    data = read_.data
 
     if TextParser is True:
         data = make_copy(data).read()
@@ -81,25 +77,23 @@ def test_select_from_list(TextParser):
 
 @pytest.mark.parametrize("TextParser", [True, False])
 def test_inspect_count_by_cat(TextParser):
-    read_ = _get_data(TextParser)
-    result = read_.unique(columns=("c1", "B1"))
+    data = _get_data(TextParser)
+    result = data.unique(columns=("c1", "B1"))
     assert result == {("c1", "B1"): {19: 1, 26: 1, 27: 1, 41: 1, 91: 1}}
 
 
 def test_replace():
-    tables = cdm_header.data.copy()
-    table_df = tables["header"]
-    result = replace_columns(
-        table_df,
+    result = cdm_header.replace_columns(
         correction_df,
+        subset="header",
         pivot_c="report_id",
         rep_c=["primary_station_id", "primary_station_id.isChange"],
     )
-    table_df["primary_station_id"] = [
+    cdm_header[("header", "primary_station_id")] = [
         "MASKSTID2",
         "MASKSTID2",
         "MASKSTID",
         "MASKSTID2",
         "MASKSTID2",
     ]
-    pd.testing.assert_frame_equal(table_df, result)
+    pd.testing.assert_frame_equal(cdm_header.data, result)

--- a/tests/test_pandas.py
+++ b/tests/test_pandas.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import numpy as np
+import pandas as pd
+import pytest  # noqa
+
+from cdm_reader_mapper import read_data
+
+from ._results import result_data
+
+
+def get_result_data(imodel):
+    results_ = getattr(result_data, f"expected_{imodel}")
+    return read_data(
+        results_["data"],
+        mask=results_["mask"],
+        info=results_["info"],
+    )
+
+
+test_data = get_result_data("icoads_r300_d700")
+
+
+def test_index():
+    index_db = test_data.index
+    index_pd = test_data.data.index
+    np.testing.assert_equal(list(index_db), list(index_pd))
+
+
+def test_size():
+    size_db = test_data.size
+    size_pd = test_data.data.size
+    np.testing.assert_equal(size_db, size_pd)
+
+
+def test_dropna():
+    dropna_db = test_data.dropna(how="any")
+    dropna_pd = test_data.data.dropna(how="any")
+    pd.testing.assert_frame_equal(dropna_db, dropna_pd)
+
+
+def test_rename():
+    _renames = {("core", "MO"): ("core", "MONTH")}
+    rename_db = test_data.rename(columns=_renames)
+    rename_pd = test_data.data.rename(columns=_renames)
+    pd.testing.assert_frame_equal(rename_db, rename_pd)
+
+
+def test_inplace():
+    _renames = {("core", "MO"): ("core", "MONTH")}
+    db1 = test_data.copy()
+    db1.rename(columns=_renames, inplace=True)
+    db2 = test_data.copy()
+    db2.data.rename(columns=_renames, inplace=True)
+    pd.testing.assert_frame_equal(db1.data, db2.data)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -23,10 +23,8 @@ def test_write_data():
 def test_write_tables(table):
     db_exp.write(suffix=f"{imodel}_{table}_all", cdm_subset=table)
     db_res = read(".", suffix=f"{imodel}_{table}_all", cdm_subset=table, mode="tables")
-    tables_exp = db_exp.data.copy()
-    table_exp = tables_exp[table].dropna(how="all").reset_index(drop=True)
-    tables_res = db_res.data.copy()
-    pd.testing.assert_frame_equal(table_exp, tables_res[table])
+    table_exp = db_exp[table].dropna(how="all").reset_index(drop=True)
+    pd.testing.assert_frame_equal(table_exp, db_res[table])
 
 
 def test_write_fns():
@@ -57,8 +55,7 @@ def test_write_filename_dict():
     }
     db_exp.write(filename=filename_dict)
     db_res = read(".", suffix=f"{imodel}_filename_dict_all", mode="tables")
-    tables_exp = db_exp.data.copy()
-    pd.testing.assert_frame_equal(tables_exp[filename_dict.keys()], db_res.data)
+    pd.testing.assert_frame_equal(db_exp[filename_dict.keys()], db_res.data)
 
 
 def test_write_col_subset():
@@ -70,7 +67,5 @@ def test_write_col_subset():
         col_subset={table: columns},
     )
     db_res = read(".", suffix=f"{imodel}_{table}_all", mode="tables")
-    tables_exp = db_exp.data.copy()
-    table_exp = tables_exp[table][columns].dropna(how="all").reset_index(drop=True)
-    tables_res = db_res.data.copy()
-    pd.testing.assert_frame_equal(table_exp, tables_res[table])
+    table_exp = db_exp[table][columns].dropna(how="all").reset_index(drop=True)
+    pd.testing.assert_frame_equal(table_exp, db_res[table])


### PR DESCRIPTION
Goal of this request
----------------------

Build ``DataBundel``object consistent with ``pandas.DataFrame``:

ToDo:
------

- [x] “catch” references to attributes that don’t exist andpass them to attribute ``data``
- [x] replace ``overwrite`` with ``inplace``
- [x] return ``DataBundle`` instead of ``DataFrame`` if ``inplace`` is ``False``

@jtsiddons: Do you have any initial comments/suggestions?