### PR TITLE
Correct self.df.attrs indexing in Configurator.open_netcdf

### DIFF
--- a/cdm_reader_mapper/mdf_reader/utils/configurator.py
+++ b/cdm_reader_mapper/mdf_reader/utils/configurator.py
@@ -249,7 +249,7 @@ class Configurator:
                 elif section in self.df.dims:
                     renames[section] = index
                 elif section in self.df.attrs:
-                    attrs[index] = self.df.attrs[index]
+                    attrs[index] = self.df.attrs[section]
                 else:
                     missing_values.append(index)
 


### PR DESCRIPTION
Conditional checks for presence of `section` in `self.df.attrs`, then tries to use `self.df.attrs[index]`. 

I think this should be `self.df.attrs[section]`