### PR TITLE
Support python 3.14

### DIFF
--- a/.github/workflows/testing-suite.yml
+++ b/.github/workflows/testing-suite.yml
@@ -27,7 +27,7 @@ jobs:
       matrix:
         os: ["ubuntu-latest"]
         # Bookend python versions
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Changelog
 
 2.1.2 (unreleased)
 ------------------
-Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`)
+Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`) and Joseph Siddons (:user:`jtsiddons`)
 
 Announcements
 ^^^^^^^^^^^^^

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,10 @@ Changelog
 ------------------
 Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`)
 
+Announcements
+^^^^^^^^^^^^^
+This release adds support for Python 3.14 (:pull:`339`)
+
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * new parameter in function `map_model` (:pull:`327`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ authors = [
 maintainers = [
   {name = "Ludwig Lierhammer", email = "ludwig.lierhammer@dwd.de"},
   {name = "Joseph Siddons", email = "joseph.siddons@noc.ac.uk"},
-  {name = "Jan Marius Willruth", email = "jan.willruth@dwd.de"},
+  {name = "Jan Marius Willruth", email = "jan.willruth@dwd.de"}
 ]
 readme = {file = "README.rst", content-type = "text/x-rst"}
 requires-python = ">=3.10"
@@ -34,7 +34,8 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
-  "Programming Language :: Python :: 3.13"
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14"
 ]
 dynamic = ["version"]
 dependencies = [


### PR DESCRIPTION
numba now supports 3.14 with release of 0.63.0: https://github.com/numba/numba/releases/tag/0.63.0

Add 3.14 to test suite, and add classifier in pyproject.toml