### PR TITLE
add reading and writing of parquet and feather data

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,14 +10,29 @@ Contributors to this version: Ludwig Lierhammer (:user:`ludwiglierhammer`)
 New features and enhancements
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 * ``mdf_reader.read_data`` now supports chunking (:pull:`360`)
+* read and write both `parquet` and `feather` files including new parameter `data_format` (:issue:`353`, :pull:`363`):
+
+  * `mdf_reader.read_data`,
+  * `mdf_reader.write_data`
+  * `cdm_mapper.read_tables`
+  * `cdm_mapper.write_tables`
 
 Breaking changes
 ^^^^^^^^^^^^^^^^
 * ``DataBundle.stack_v`` and ``DataBundle.stack_h`` only support `pd.DataFrames` as input, otherwise raises an `ValueError` (:pull:`360`)
+* set default for `extension` from `psv` to specified `data_format` (:pull:`363`):
+
+  * `cdm_mapper.read_tables`
+  * `cdm_mapper.write_tables`
+
+* set default for `extension` from ``csv`  to specified `data_format` in `mdf_reader.write_data` (:pull:`363`)
+* `mdf_reader.read_data`: save `dtypes` in return DataBundle as `pd.Series` not `dict` (:pull:`363`)
 
 Internal changes
 ^^^^^^^^^^^^^^^^
 * re-work internal structure for more readability and better performance (:pull:`360`)
+* use pre-defined `Literal` constants in `cdm_reader_mapper.properties` (:pull:`363`)
+* `mdf_reader.utils.utilities.read_csv`: parameter `columns` to `column_names` (:pull:`363`)
 
 2.2.1 (2026-01-23)
 ------------------

--- a/cdm_reader_mapper/cdm_mapper/mapper.py
+++ b/cdm_reader_mapper/cdm_mapper/mapper.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 from copy import deepcopy
 from io import StringIO
-from typing import Any
+from typing import Any, get_args
 
 import numpy as np
 import pandas as pd
@@ -533,7 +533,7 @@ def map_model(
     """
     logger = logging_hdlr.init_logger(__name__, level=log_level)
     imodel = imodel.split("_")
-    if imodel[0] not in properties.supported_data_models:
+    if imodel[0] not in get_args(properties.SupportedDataModels):
         logger.error("Input data model " f"{imodel[0]}" " not supported")
         return
 

--- a/cdm_reader_mapper/cdm_mapper/properties.py
+++ b/cdm_reader_mapper/cdm_mapper/properties.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from ..properties import numeric_types, object_types, supported_data_models  # noqa
+from ..properties import NumericTypes, ObjectTypes, SupportedDataModels  # noqa
 
 _base = "cdm_reader_mapper.cdm_mapper"
 

--- a/cdm_reader_mapper/cdm_mapper/reader.py
+++ b/cdm_reader_mapper/cdm_mapper/reader.py
@@ -47,14 +47,15 @@ from __future__ import annotations
 import glob
 import os
 
-from typing import Literal
+from typing import get_args
 
 import pandas as pd
 
 from cdm_reader_mapper.common import get_filename, logging_hdlr
 from cdm_reader_mapper.core.databundle import DataBundle
 
-from . import properties
+from ..properties import SupportedFileTypes
+from .properties import cdm_tables
 from .utils.utilities import get_cdm_subset, get_usecols
 
 
@@ -62,7 +63,7 @@ def _read_file(
     ifile: str,
     table: str,
     col_subset: str | list | None,
-    data_format: Literal["csv", "parquet", "feather"],
+    data_format: SupportedFileTypes,
     **kwargs,
 ) -> pd.DataFrame:
     usecols = get_usecols(table, col_subset)
@@ -73,7 +74,7 @@ def _read_file(
     if data_format == "feather":
         return pd.read_feather(ifile, columns=usecols, **kwargs)
     raise ValueError(
-        f"data_format must be one of [csv, parquet, feather] not {data_format}."
+        f"data_format must be one of {get_args(SupportedFileTypes)} not {data_format}."
     )
 
 
@@ -121,7 +122,7 @@ def _read_multiple_files(
         cdm_subset = [cdm_subset]
 
     for table in cdm_subset:
-        if table not in properties.cdm_tables:
+        if table not in cdm_tables:
             logger.warning(f"Requested table {table} not defined in CDM")
             continue
 
@@ -159,7 +160,7 @@ def _read_multiple_files(
 
 def read_tables(
     source: str,
-    data_format: Literal["csv", "parquet", "feather"] = "csv",
+    data_format: SupportedFileTypes = "csv",
     prefix: str | None = None,
     suffix: str | None = None,
     extension: str | None = None,
@@ -233,9 +234,10 @@ def read_tables(
     write_data : Write MDF data and validation mask to disk.
     """
     logger = logging_hdlr.init_logger(__name__, level="INFO")
-    if data_format not in ["csv", "parquet", "feather"]:
+    supported_file_types = get_args(SupportedFileTypes)
+    if data_format not in supported_file_types:
         raise ValueError(
-            f"data_format must be one of [csv, parquet, feather] not {data_format}."
+            f"data_format must be one of {supported_file_types}, not {data_format}."
         )
 
     # Because how the printers are written, they modify the original data frame!,

--- a/cdm_reader_mapper/cdm_mapper/reader.py
+++ b/cdm_reader_mapper/cdm_mapper/reader.py
@@ -143,9 +143,12 @@ def _read_multiple_files(
             continue
 
         logger.info(f"Getting file path for pattern {table}")
-        pattern_ = get_filename(
-            [prefix, table, f"*{suffix}"], path=inp_dir, extension=extension
-        )
+        _pattern = [table]
+        if prefix:
+            _pattern = [prefix] + _pattern
+        if suffix:
+            _pattern = _pattern + [f"*{suffix}"]
+        pattern_ = get_filename(_pattern, path=inp_dir, extension=extension)
         paths_ = glob.glob(pattern_)
         if len(paths_) != 1:
             logger.warning(

--- a/cdm_reader_mapper/cdm_mapper/reader.py
+++ b/cdm_reader_mapper/cdm_mapper/reader.py
@@ -99,7 +99,7 @@ def _read_multiple_files(
     inp_dir: str,
     prefix: str | None = None,
     suffix: str | None = None,
-    extension: str = "psv",
+    extension: str | None = None,
     cdm_subset: str | list | None = None,
     col_subset: str | list | None = None,
     null_label: str = "null",
@@ -114,12 +114,12 @@ def _read_multiple_files(
     files = glob.glob(pattern)
 
     if len(files) == 0:
-        logger.error(f"No files found matching pattern {pattern}")
-        return [pd.DataFrame()]
+        raise FileNotFoundError(f"No files found matching pattern {pattern}")
 
     df_list = []
     if not isinstance(cdm_subset, list):
         cdm_subset = [cdm_subset]
+
     for table in cdm_subset:
         if table not in properties.cdm_tables:
             logger.warning(f"Requested table {table} not defined in CDM")

--- a/cdm_reader_mapper/cdm_mapper/reader.py
+++ b/cdm_reader_mapper/cdm_mapper/reader.py
@@ -104,6 +104,7 @@ def _read_single_file(
     )
     if dfi_.empty:
         return pd.DataFrame()
+
     dfi_ = dfi_.set_index("report_id", drop=False)
     if null_label in dfi_.index:
         return dfi_.drop(index=null_label)

--- a/cdm_reader_mapper/cdm_mapper/reader.py
+++ b/cdm_reader_mapper/cdm_mapper/reader.py
@@ -249,8 +249,7 @@ def read_tables(
     # See if subset, if any of the tables is not as specs
     cdm_subset = get_cdm_subset(cdm_subset)
 
-    if extension is None:
-        extension = data_format
+    extension = extension or data_format
 
     if os.path.isfile(source):
         df_list = [

--- a/cdm_reader_mapper/cdm_mapper/writer.py
+++ b/cdm_reader_mapper/cdm_mapper/writer.py
@@ -60,9 +60,10 @@ def _table_to_file(
         data.to_parquet(filename, **kwargs)
     elif data_format == "feather":
         data.to_feather(filename, **kwargs)
-    raise ValueError(
-        f"data_format must be one of [csv, parquet, feather] not {data_format}."
-    )
+    else:
+        raise ValueError(
+            f"data_format must be one of [csv, parquet, feather] not {data_format}."
+        )
 
 
 def write_tables(
@@ -163,6 +164,9 @@ def write_tables(
 
     if out_dir is None:
         out_dir = "."
+
+    if extension is None:
+        extension = data_format
 
     for table in cdm_subset:
         if table not in data:

--- a/cdm_reader_mapper/cdm_mapper/writer.py
+++ b/cdm_reader_mapper/cdm_mapper/writer.py
@@ -27,18 +27,20 @@ import os
 import pandas as pd
 
 from pathlib import Path
-from typing import Literal
+from typing import get_args
 
 from cdm_reader_mapper.common import get_filename, logging_hdlr
 
 from .tables.tables import get_cdm_atts
 from .utils.utilities import adjust_filename, dict_to_tuple_list, get_cdm_subset
 
+from ..properties import SupportedFileTypes
+
 
 def _table_to_file(
     data: pd.DataFrame,
     filename=None,
-    data_format: Literal["csv", "parquet", "feather"] = "csv",
+    data_format: SupportedFileTypes = "csv",
     delimiter: str = "|",
     encoding: str = "utf-8",
     **kwargs,
@@ -62,13 +64,13 @@ def _table_to_file(
         data.to_feather(filename, **kwargs)
     else:
         raise ValueError(
-            f"data_format must be one of [csv, parquet, feather] not {data_format}."
+            f"data_format must be one of {get_args(SupportedFileTypes)} not {data_format}."
         )
 
 
 def write_tables(
     data: pd.DataFrame,
-    data_format: Literal["csv", "parquet", "feather"] = "csv",
+    data_format: SupportedFileTypes = "csv",
     out_dir: str | None = None,
     prefix: str | None = None,
     suffix: str | None = None,
@@ -139,9 +141,10 @@ def write_tables(
     Use this function after reading CDM tables.
     """
     logger = logging_hdlr.init_logger(__name__, level="INFO")
-    if data_format not in ["csv", "parquet", "feather"]:
+    supported_file_types = get_args(SupportedFileTypes)
+    if data_format not in supported_file_types:
         raise ValueError(
-            f"data_format must be one of [csv, parquet, feather] not {data_format}."
+            f"data_format must be one of {supported_file_types}, not {data_format}."
         )
 
     cdm_subset = get_cdm_subset(cdm_subset)

--- a/cdm_reader_mapper/cdm_mapper/writer.py
+++ b/cdm_reader_mapper/cdm_mapper/writer.py
@@ -162,11 +162,9 @@ def write_tables(
     elif filename is None:
         filename = {}
 
-    if out_dir is None:
-        out_dir = "."
+    out_dir = out_dir or "."
 
-    if extension is None:
-        extension = data_format
+    extension = extension or data_format
 
     for table in cdm_subset:
         if table not in data:

--- a/cdm_reader_mapper/common/pandas_TextParser_hdlr.py
+++ b/cdm_reader_mapper/common/pandas_TextParser_hdlr.py
@@ -1,6 +1,7 @@
 """Utilities for handling pandas TextParser objects safely."""
 
 from __future__ import annotations
+
 import pandas as pd
 from pandas.io.parsers import TextFileReader
 from io import StringIO

--- a/cdm_reader_mapper/common/pandas_TextParser_hdlr.py
+++ b/cdm_reader_mapper/common/pandas_TextParser_hdlr.py
@@ -9,7 +9,7 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-_READ_CSV_KWARGS = [
+READ_CSV_KWARGS = [
     "chunksize",
     "names",
     "dtype",
@@ -47,7 +47,7 @@ def _new_reader_from_buffer(parser: TextFileReader) -> TextFileReader | None:
 
     read_dict = read_dict = {
         k: parser.orig_options.get(k)
-        for k in _READ_CSV_KWARGS
+        for k in READ_CSV_KWARGS
         if k in parser.orig_options
     }
     return pd.read_csv(StringIO(raw), **read_dict)

--- a/cdm_reader_mapper/common/replace.py
+++ b/cdm_reader_mapper/common/replace.py
@@ -19,7 +19,6 @@ Replacement arguments:
 
 from __future__ import annotations
 
-
 import pandas as pd
 
 from . import logging_hdlr

--- a/cdm_reader_mapper/core/databundle.py
+++ b/cdm_reader_mapper/core/databundle.py
@@ -35,11 +35,11 @@ class DataBundle(_DataBundle):
     ----------
     data: pandas.DataFrame, optional
         MDF DataFrame.
-    columns: list, optional
+    columns: pd.Index, pd.MultiIndex or list, optional
         Column labels of ``data``
-    dtypes: dict, optional
+    dtypes: pd.Series or dict, optional
         Data types of ``data``.
-    parse_dates: list, optional
+    parse_dates: list or bool, optional
         Information how to parse dates on ``data``
     mask: pandas.DataFrame, optional
         MDF validation mask

--- a/cdm_reader_mapper/mdf_reader/properties.py
+++ b/cdm_reader_mapper/mdf_reader/properties.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from ..properties import numeric_types, object_types, supported_data_models  # noqa
+from typing import get_args
+
+from ..properties import NumericTypes, ObjectTypes, SupportedDataModels  # noqa
 
 _base = "cdm_reader_mapper.mdf_reader"
 
@@ -17,16 +19,16 @@ year_column = {
 }
 
 pandas_dtypes = {}
-for dtype in object_types:
+for dtype in get_args(ObjectTypes):
     pandas_dtypes[dtype] = "object"
-pandas_dtypes.update({x: x for x in numeric_types})
+pandas_dtypes.update({x: x for x in get_args(NumericTypes)})
 pandas_dtypes["datetime"] = "datetime"
 
 pandas_int = "Int64"
 
 # ....and how they are managed
 data_type_conversion_args = {}
-for dtype in numeric_types:
+for dtype in get_args(NumericTypes):
     data_type_conversion_args[dtype] = ["scale", "offset"]
 data_type_conversion_args["str"] = ["disable_white_strip"]
 data_type_conversion_args["object"] = ["disable_white_strip"]

--- a/cdm_reader_mapper/mdf_reader/reader.py
+++ b/cdm_reader_mapper/mdf_reader/reader.py
@@ -231,7 +231,7 @@ def read_mdf(
 
 def _read_data(
     data_file: str,
-    mask_file: str,
+    mask_file: str | None,
     reader: Callable[..., Any],
     col_subset: str | list | tuple | None,
     data_kwargs: dict,
@@ -341,7 +341,7 @@ def read_data(
     return DataBundle(
         data=data,
         columns=info["columns"],
-        dtypes=info["dtypes"].to_dict(),
+        dtypes=info["dtypes"],
         parse_dates=parse_dates,
         mask=mask,
         imodel=imodel,

--- a/cdm_reader_mapper/mdf_reader/reader.py
+++ b/cdm_reader_mapper/mdf_reader/reader.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal, Callable, Any
+from typing import Callable, Any, get_args
 
 import pandas as pd
 
@@ -16,6 +16,7 @@ from .utils.utilities import validate_arg
 
 from .utils.utilities import as_list, as_path, read_csv, read_parquet, read_feather
 
+from ..properties import SupportedFileTypes
 
 READERS = {
     "csv": read_csv,
@@ -260,7 +261,7 @@ def read_data(
     data_file: str,
     mask_file: str | None = None,
     info_file: str | None = None,
-    data_format: Literal["csv", "parquet", "feather"] = "csv",
+    data_format: SupportedFileTypes = "csv",
     imodel: str | None = None,
     col_subset: str | list | tuple | None = None,
     encoding: str | None = None,
@@ -307,9 +308,10 @@ def read_data(
     write_data : Write MDF data and validation mask to disk.
     write_tables : Write CDM tables to disk.
     """
-    if data_format not in ["csv", "parquet", "feather"]:
+    supported_file_types = get_args(SupportedFileTypes)
+    if data_format not in supported_file_types:
         raise ValueError(
-            f"data_format must be one of [csv, parquet, feather] not {data_format}."
+            f"data_format must be one of {supported_file_types}, not {data_format}."
         )
 
     data_kwargs = kwargs.copy()

--- a/cdm_reader_mapper/mdf_reader/reader.py
+++ b/cdm_reader_mapper/mdf_reader/reader.py
@@ -153,8 +153,8 @@ def read_mdf(
     write_data : Write MDF data and validation mask to disk.
     write_tables : Write CDM tables to disk.
     """
-    if skiprows is None:
-        skiprows = 0
+    skiprows = skiprows or 0
+
     validate_read_mdf_args(
         source=source,
         imodel=imodel,

--- a/cdm_reader_mapper/mdf_reader/reader.py
+++ b/cdm_reader_mapper/mdf_reader/reader.py
@@ -314,6 +314,7 @@ def read_data(
 
     data_kwargs = kwargs.copy()
     mask_kwargs = kwargs.copy()
+    parse_dates = False
     if data_format == "csv":
         info_dict = open_json_file(info_file) if info_file else {}
         dtype = info_dict.get("dtypes", "object")

--- a/cdm_reader_mapper/mdf_reader/reader.py
+++ b/cdm_reader_mapper/mdf_reader/reader.py
@@ -291,7 +291,7 @@ def read_data(
         pd_kwargs.setdefault("dtype", "boolean")
 
         mask, _ = read_csv(
-            mask_file, col_subset=col_subset, columns=infos["columns"], **pd_kwargs
+            mask_file, col_subset=col_subset, column_names=infos["columns"], **pd_kwargs
         )
     elif data_format == "parquet":
         data, infos = read_parquet(
@@ -303,7 +303,7 @@ def read_data(
         mask, _ = read_parquet(
             mask_file,
             col_subset=col_subset,
-            columns=infos["columns"] ** kwargs,
+            column_names=infos["columns"] ** kwargs,
         )
     elif data_format == "feather":
         data, infos = read_feather(
@@ -315,7 +315,7 @@ def read_data(
         mask, _ = read_feather(
             mask_file,
             col_subset=col_subset,
-            columns=infos["columns"] ** kwargs,
+            column_names=infos["columns"] ** kwargs,
         )
     else:
         raise ValueError(

--- a/cdm_reader_mapper/mdf_reader/schemas/schemas.py
+++ b/cdm_reader_mapper/mdf_reader/schemas/schemas.py
@@ -10,7 +10,7 @@ requirements of the data reader tool
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TypedDict
+from typing import TypedDict, get_args
 
 from cdm_reader_mapper.common.json_dict import collect_json_files, combine_dicts
 
@@ -109,7 +109,7 @@ def _resolve_schema_files(
     if imodel:
         parts = imodel.split("_")
         model = parts[0]
-        if model not in properties.supported_data_models:
+        if model not in get_args(properties.SupportedDataModels):
             raise ValueError(f"Input data model {model} not supported")
 
         return collect_json_files(*parts, base=f"{properties._base}.schemas")

--- a/cdm_reader_mapper/mdf_reader/utils/convert_and_decode.py
+++ b/cdm_reader_mapper/mdf_reader/utils/convert_and_decode.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from decimal import Decimal, InvalidOperation
-from typing import Callable, Any
+from typing import Callable, Any, get_args
 
 import pandas as pd
 
 from .. import properties
 from .utilities import convert_str_boolean
+
+numeric_types = get_args(properties.NumericTypes)
 
 
 def max_decimal_places(*decimals: Decimal) -> int:
@@ -102,7 +104,7 @@ class Decoders:
 
         self._registry = {"key": self.base36}
 
-        for numeric_type in properties.numeric_types:
+        for numeric_type in numeric_types:
             self._registry[numeric_type] = self.base36
 
     def decoder(self) -> Callable[[pd.Series], pd.Series] | None:
@@ -189,7 +191,7 @@ class Converters:
             "key": self.object_to_object,
         }
 
-        for numeric_type in properties.numeric_types:
+        for numeric_type in numeric_types:
             self._registry[numeric_type] = self.object_to_numeric
 
     def converter(self) -> Callable[..., pd.Series]:

--- a/cdm_reader_mapper/mdf_reader/utils/utilities.py
+++ b/cdm_reader_mapper/mdf_reader/utils/utilities.py
@@ -280,7 +280,7 @@ def read_csv(
         reader=pd.read_csv,
         col_subset=col_subset,
         column_names=column_names,
-        reader_kwargs={"delimiter": ",", **kwargs},
+        reader_kwargs=kwargs,
         iterator=True,
     )
 
@@ -512,6 +512,8 @@ def process_textfilereader(
         read_kwargs = {}
     if write_kwargs is None:
         write_kwargs = {}
+
+    read_kwargs = {k: v for k, v in read_kwargs.items() if k != "delimiter"}
 
     buffers = []
     columns = []

--- a/cdm_reader_mapper/mdf_reader/utils/utilities.py
+++ b/cdm_reader_mapper/mdf_reader/utils/utilities.py
@@ -230,9 +230,9 @@ def _read_data_from_file(
         return update_and_select(data, subset=col_subset, column_names=column_names)
 
     if iterator is True:
-        write_kwargs = {}
+        writer_kwargs = {}
         if "encoding" in reader_kwargs:
-            write_kwargs["encoding"] = reader_kwargs["encoding"]
+            writer_kwargs["encoding"] = reader_kwargs["encoding"]
 
         return process_textfilereader(
             data,
@@ -242,7 +242,7 @@ def _read_data_from_file(
                 "column_names": column_names,
             },
             read_kwargs=reader_kwargs,
-            write_kwargs=write_kwargs,
+            write_kwargs=writer_kwargs,
             makecopy=False,
         )
 
@@ -506,14 +506,9 @@ def process_textfilereader(
             - One or more processed DataFrames (in the same order as returned by `func`)
             - Any additional outputs from `func` that are not DataFrames
     """
-    if func_kwargs is None:
-        func_kwargs = {}
-    if read_kwargs is None:
-        read_kwargs = {}
-    if write_kwargs is None:
-        write_kwargs = {}
-
-    read_kwargs = {k: v for k, v in read_kwargs.items() if k != "delimiter"}
+    func_kwargs = func_kwargs or {}
+    read_kwargs = read_kwargs or {}
+    write_kwargs = write_kwargs or {}
 
     buffers = []
     columns = []
@@ -560,6 +555,7 @@ def process_textfilereader(
     result_dfs = []
     for buffer, cols, rk in zip(buffers, columns, read_kwargs):
         buffer.seek(0)
+        rk = {k: v for k, v in rk.items() if k != "delimiter"}
         result_dfs.append(
             pd.read_csv(
                 buffer,

--- a/cdm_reader_mapper/mdf_reader/utils/validators.py
+++ b/cdm_reader_mapper/mdf_reader/utils/validators.py
@@ -6,11 +6,14 @@ import logging
 import numpy as np
 import pandas as pd
 
-from typing import Any, Iterable
+from typing import Any, Iterable, get_args
 
 from .. import properties
 from ..codes import codes
 from .utilities import convert_str_boolean
+
+
+numeric_types = get_args(properties.NumericTypes)
 
 
 def _is_false(x: Any) -> bool:
@@ -173,7 +176,7 @@ def validate(
     }
 
     validated_columns = []
-    validated_dtypes = set(properties.numeric_types) | {"datetime", "key"}
+    validated_dtypes = set(numeric_types) | {"datetime", "key"}
 
     basic_functions = {
         "datetime": validate_datetime,
@@ -188,7 +191,7 @@ def validate(
         column_atts = element_atts.get(column, {})
         column_type = column_atts.get("column_type")
 
-        if column_type in properties.numeric_types:
+        if column_type in numeric_types:
             valid_min = column_atts.get("valid_min", -np.inf)
             valid_max = column_atts.get("valid_max", np.inf)
             column_mask = validate_numeric(series, valid_min, valid_max)

--- a/cdm_reader_mapper/mdf_reader/writer.py
+++ b/cdm_reader_mapper/mdf_reader/writer.py
@@ -56,7 +56,7 @@ def write_data(
     data: pd.DataFrame | TextFileReader,
     mask: pd.DataFrame | TextFileReader | None = None,
     data_format: SupportedFileTypes = "csv",
-    dtypes: dict | None = None,
+    dtypes: pd.Series | dict | None = None,
     parse_dates: list | bool = False,
     encoding: str = "utf-8",
     out_dir: str = ".",
@@ -134,7 +134,9 @@ def write_data(
 
     extension = extension or data_format
 
-    dtypes = dtypes or {}
+    if not isinstance(dtypes, (dict, pd.Series)):
+        dtypes = {}
+
     if isinstance(parse_dates, bool):
         parse_dates = []
 

--- a/cdm_reader_mapper/mdf_reader/writer.py
+++ b/cdm_reader_mapper/mdf_reader/writer.py
@@ -138,7 +138,10 @@ def write_data(
     data_list = _normalize_data_chunks(data)
     mask_list = _normalize_data_chunks(mask)
 
-    info = {"dtypes": dtypes.copy(), "parse_dates": [join(p) for p in parse_dates]}
+    info = {
+        "dtypes": {k: str(v) for k, v in dtypes.items()},
+        "parse_dates": [join(p) for p in parse_dates],
+    }
 
     logging.info(f"WRITING DATA TO FILES IN: {out_dir}")
     out_dir = Path(out_dir)

--- a/cdm_reader_mapper/mdf_reader/writer.py
+++ b/cdm_reader_mapper/mdf_reader/writer.py
@@ -6,7 +6,7 @@ import json
 import logging
 from io import StringIO as StringIO
 from pathlib import Path
-from typing import Literal, Any
+from typing import Any, get_args
 
 import pandas as pd
 from pandas.io.parsers import TextFileReader
@@ -15,6 +15,8 @@ from .utils.utilities import join, update_column_names, update_dtypes
 
 from ..common import get_filename
 from ..common.pandas_TextParser_hdlr import make_copy
+
+from ..properties import SupportedFileTypes
 
 WRITERS = {
     "csv": "to_csv",
@@ -53,7 +55,7 @@ def _write_data(
 def write_data(
     data: pd.DataFrame | TextFileReader,
     mask: pd.DataFrame | TextFileReader | None = None,
-    data_format: Literal["csv", "parquet", "feather"] = "csv",
+    data_format: SupportedFileTypes = "csv",
     dtypes: dict | None = None,
     parse_dates: list | bool = False,
     encoding: str = "utf-8",
@@ -124,9 +126,10 @@ def write_data(
     ----
     Use this function after reading MDF data.
     """
-    if data_format not in ["csv", "parquet", "feather"]:
+    supported_file_types = get_args(SupportedFileTypes)
+    if data_format not in supported_file_types:
         raise ValueError(
-            f"data_format must be one of [csv, parquet, feather] not {data_format}."
+            f"data_format must be one of {supported_file_types}, not {data_format}."
         )
 
     extension = extension or data_format

--- a/cdm_reader_mapper/mdf_reader/writer.py
+++ b/cdm_reader_mapper/mdf_reader/writer.py
@@ -27,7 +27,8 @@ def _normalize_data_chunks(
     data: pd.DataFrame | TextFileReader | None,
 ) -> list | TextFileReader:
     """Helper function to normalize data chunks."""
-    data = data or pd.DataFrame()
+    if data is None:
+        data = pd.DataFrame()
     if isinstance(data, pd.DataFrame):
         return [data]
     if isinstance(data, TextFileReader):

--- a/cdm_reader_mapper/properties.py
+++ b/cdm_reader_mapper/properties.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-numeric_types = ["Int64", "int", "float"]
+from typing import Literal
 
-object_types = ["str", "object", "key", "datetime"]
+NumericTypes = Literal["Int64", "int", "float"]
 
-supported_data_models = ["craid", "gdac", "icoads", "pub47"]
+ObjectTypes = Literal["str", "object", "key", "datetime"]
+
+SupportedDataModels = Literal["craid", "gdac", "icoads", "pub47"]
+
+SupportedFileTypes = Literal["csv", "parquet", "feather"]

--- a/cdm_reader_mapper/properties.py
+++ b/cdm_reader_mapper/properties.py
@@ -11,3 +11,7 @@ ObjectTypes = Literal["str", "object", "key", "datetime"]
 SupportedDataModels = Literal["craid", "gdac", "icoads", "pub47"]
 
 SupportedFileTypes = Literal["csv", "parquet", "feather"]
+
+SupportedReadModes = Literal["mdf", "data", "tables"]
+
+SupportedWriteModes = Literal["data", "tables"]

--- a/tests/_duplicates.py
+++ b/tests/_duplicates.py
@@ -132,6 +132,7 @@ def _get_test_data(imodel):
         suffix=f"{imodel}*",
         cdm_subset="header",
         mode="tables",
+        extension="psv",
     )
 
 

--- a/tests/test_cdm_io.py
+++ b/tests/test_cdm_io.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from cdm_reader_mapper.cdm_mapper.reader import read_tables
+from cdm_reader_mapper.cdm_mapper.writer import write_tables
+
+
+@pytest.fixture
+def example_data():
+    arrays = [
+        ["header", "header", "observations-sst", "observations-sst"],
+        ["report_id", "A", "report_id", "B"],
+    ]
+    multi_cols = pd.MultiIndex.from_arrays(arrays)
+    return pd.DataFrame(
+        [
+            [1, 0.5, 1, "a"],
+            [2, 5.0, 2, "b"],
+            [3, 1.3, 3, "c"],
+        ],
+        columns=multi_cols,
+    )
+
+
+@pytest.fixture
+def csv_path(tmp_path, example_data):
+    header_file = tmp_path / "header-test.csv"
+    obssst_file = tmp_path / "observations-sst-test.csv"
+
+    example_data["header"].to_csv(header_file, index=False)
+    example_data["observations-sst"].to_csv(obssst_file, index=False)
+
+    return tmp_path
+
+
+@pytest.fixture
+def parquet_path(tmp_path, example_data):
+    header_file = tmp_path / "header-test.parquet"
+    obssst_file = tmp_path / "observations-sst-test.parquet"
+
+    example_data["header"].to_parquet(header_file, index=False)
+    example_data["observations-sst"].to_parquet(obssst_file, index=False)
+
+    return tmp_path
+
+
+@pytest.fixture
+def feather_path(tmp_path, example_data):
+    header_file = tmp_path / "header-test.feather"
+    obssst_file = tmp_path / "observations-sst-test.feather"
+
+    example_data["header"].to_feather(
+        header_file,
+    )
+    example_data["observations-sst"].to_feather(obssst_file)
+
+    return tmp_path
+
+
+def test_read_data_csv(csv_path, example_data):
+    bundle = read_tables(csv_path, delimiter=",")
+    pd.testing.assert_frame_equal(bundle.data, example_data.astype(str))
+
+
+def test_read_data_parquet(parquet_path, example_data):
+    bundle = read_tables(parquet_path, data_format="parquet")
+    pd.testing.assert_frame_equal(bundle.data, example_data)
+
+
+def test_read_data_feather(feather_path, example_data):
+    bundle = read_tables(feather_path, data_format="feather")
+    pd.testing.assert_frame_equal(bundle.data, example_data)
+
+
+def test_write_data_csv(tmp_path, example_data):
+    write_tables(example_data, out_dir=tmp_path, suffix="test")
+    data_header = pd.read_csv(tmp_path / "header-test.csv", delimiter="|")
+    data_obssst = pd.read_csv(tmp_path / "observations-sst-test.csv", delimiter="|")
+    pd.testing.assert_frame_equal(example_data["header"], data_header)
+    pd.testing.assert_frame_equal(example_data["observations-sst"], data_obssst)
+
+
+def test_write_data_parquet(tmp_path, example_data):
+    write_tables(example_data, out_dir=tmp_path, suffix="test", data_format="parquet")
+    data_header = pd.read_parquet(tmp_path / "header-test.parquet")
+    data_obssst = pd.read_parquet(tmp_path / "observations-sst-test.parquet")
+    pd.testing.assert_frame_equal(example_data["header"], data_header)
+    pd.testing.assert_frame_equal(example_data["observations-sst"], data_obssst)
+
+
+def test_write_data_feather(tmp_path, example_data):
+    write_tables(example_data, out_dir=tmp_path, suffix="test", data_format="feather")
+    data_header = pd.read_feather(tmp_path / "header-test.feather")
+    data_obssst = pd.read_feather(tmp_path / "observations-sst-test.feather")
+    pd.testing.assert_frame_equal(example_data["header"], data_header)
+    pd.testing.assert_frame_equal(example_data["observations-sst"], data_obssst)

--- a/tests/test_cdm_io.py
+++ b/tests/test_cdm_io.py
@@ -26,8 +26,8 @@ def example_data():
 
 @pytest.fixture
 def csv_path(tmp_path, example_data):
-    header_file = tmp_path / "header-test.csv"
-    obssst_file = tmp_path / "observations-sst-test.csv"
+    header_file = tmp_path / "header.csv"
+    obssst_file = tmp_path / "observations-sst.csv"
 
     example_data["header"].to_csv(header_file, index=False)
     example_data["observations-sst"].to_csv(obssst_file, index=False)
@@ -37,8 +37,8 @@ def csv_path(tmp_path, example_data):
 
 @pytest.fixture
 def parquet_path(tmp_path, example_data):
-    header_file = tmp_path / "header-test.parquet"
-    obssst_file = tmp_path / "observations-sst-test.parquet"
+    header_file = tmp_path / "header.parquet"
+    obssst_file = tmp_path / "observations-sst.parquet"
 
     example_data["header"].to_parquet(header_file, index=False)
     example_data["observations-sst"].to_parquet(obssst_file, index=False)
@@ -48,8 +48,8 @@ def parquet_path(tmp_path, example_data):
 
 @pytest.fixture
 def feather_path(tmp_path, example_data):
-    header_file = tmp_path / "header-test.feather"
-    obssst_file = tmp_path / "observations-sst-test.feather"
+    header_file = tmp_path / "header.feather"
+    obssst_file = tmp_path / "observations-sst.feather"
 
     example_data["header"].to_feather(
         header_file,
@@ -75,24 +75,24 @@ def test_read_data_feather(feather_path, example_data):
 
 
 def test_write_data_csv(tmp_path, example_data):
-    write_tables(example_data, out_dir=tmp_path, suffix="test")
-    data_header = pd.read_csv(tmp_path / "header-test.csv", delimiter="|")
-    data_obssst = pd.read_csv(tmp_path / "observations-sst-test.csv", delimiter="|")
+    write_tables(example_data, out_dir=tmp_path)
+    data_header = pd.read_csv(tmp_path / "header.csv", delimiter="|")
+    data_obssst = pd.read_csv(tmp_path / "observations-sst.csv", delimiter="|")
     pd.testing.assert_frame_equal(example_data["header"], data_header)
     pd.testing.assert_frame_equal(example_data["observations-sst"], data_obssst)
 
 
 def test_write_data_parquet(tmp_path, example_data):
-    write_tables(example_data, out_dir=tmp_path, suffix="test", data_format="parquet")
-    data_header = pd.read_parquet(tmp_path / "header-test.parquet")
-    data_obssst = pd.read_parquet(tmp_path / "observations-sst-test.parquet")
+    write_tables(example_data, out_dir=tmp_path, data_format="parquet")
+    data_header = pd.read_parquet(tmp_path / "header.parquet")
+    data_obssst = pd.read_parquet(tmp_path / "observations-sst.parquet")
     pd.testing.assert_frame_equal(example_data["header"], data_header)
     pd.testing.assert_frame_equal(example_data["observations-sst"], data_obssst)
 
 
 def test_write_data_feather(tmp_path, example_data):
-    write_tables(example_data, out_dir=tmp_path, suffix="test", data_format="feather")
-    data_header = pd.read_feather(tmp_path / "header-test.feather")
-    data_obssst = pd.read_feather(tmp_path / "observations-sst-test.feather")
+    write_tables(example_data, out_dir=tmp_path, data_format="feather")
+    data_header = pd.read_feather(tmp_path / "header.feather")
+    data_obssst = pd.read_feather(tmp_path / "observations-sst.feather")
     pd.testing.assert_frame_equal(example_data["header"], data_header)
     pd.testing.assert_frame_equal(example_data["observations-sst"], data_obssst)

--- a/tests/test_databundle.py
+++ b/tests/test_databundle.py
@@ -70,7 +70,7 @@ def sample_db_df_testdata():
     mask = test_data[f"test_{data_model}"]["mdf_mask"]
     info = test_data[f"test_{data_model}"]["mdf_info"]
 
-    return read_data(data, mask=mask, info=info)
+    return read_data(data_file=data, mask_file=mask, info_file=info)
 
 
 @pytest.fixture
@@ -80,7 +80,7 @@ def sample_db_reader_testdata():
     mask = test_data[f"test_{data_model}"]["mdf_mask"]
     info = test_data[f"test_{data_model}"]["mdf_info"]
 
-    return read_data(data, mask=mask, info=info, chunksize=2)
+    return read_data(data_file=data, mask_file=mask, info_file=info, chunksize=2)
 
 
 def test_len_df(sample_db_df):

--- a/tests/test_mdf_reader.py
+++ b/tests/test_mdf_reader.py
@@ -38,7 +38,7 @@ def _read_mdf_test_data(data_model, select=None, drop=None, drop_idx=None, **kwa
     mask = test_data[f"test_{data_model}"]["mdf_mask"]
     info = test_data[f"test_{data_model}"]["mdf_info"]
 
-    expected = read_data(data, mask=mask, info=info)
+    expected = read_data(data_file=data, mask_file=mask, info_file=info)
 
     if not isinstance(result.data, pd.DataFrame):
         result.data = result.data.read()
@@ -242,7 +242,7 @@ def test_read_data_no_mask():
     data_model = "icoads_r300_d721"
     data = test_data[f"test_{data_model}"]["mdf_data"]
     info = test_data[f"test_{data_model}"]["mdf_info"]
-    db = read_data(data, info=info)
+    db = read_data(data_file=data, info_file=info)
 
     assert isinstance(db, DataBundle)
 
@@ -277,7 +277,7 @@ def test_read_data_no_info():
     data_model = "icoads_r300_d721"
     data = test_data[f"test_{data_model}"]["mdf_data"]
 
-    db = read_data(data)
+    db = read_data(data_file=data)
 
     assert isinstance(db, DataBundle)
 
@@ -311,7 +311,7 @@ def test_read_data_col_subset():
     data_model = "icoads_r300_d721"
     data = test_data[f"test_{data_model}"]["mdf_data"]
     info = test_data[f"test_{data_model}"]["mdf_info"]
-    db = read_data(data, info=info, col_subset="core")
+    db = read_data(data_file=data, info_file=info, col_subset="core")
 
     assert isinstance(db, DataBundle)
 
@@ -345,7 +345,7 @@ def test_read_data_col_subset():
 def test_read_data_encoding():
     data_model = "icoads_r300_d721"
     data = test_data[f"test_{data_model}"]["mdf_data"]
-    db = read_data(data, encoding="cp1252")
+    db = read_data(data_file=data, encoding="cp1252")
 
     assert isinstance(db, DataBundle)
 
@@ -381,7 +381,7 @@ def test_read_data_textfilereader():
     data = test_data[f"test_{data_model}"]["mdf_data"]
     mask = test_data[f"test_{data_model}"]["mdf_mask"]
     info = test_data[f"test_{data_model}"]["mdf_info"]
-    db = read_data(data, mask=mask, info=info, chunksize=3)
+    db = read_data(data_file=data, mask_file=mask, info_file=info, chunksize=3)
 
     assert isinstance(db, DataBundle)
 

--- a/tests/test_mdf_reader.py
+++ b/tests/test_mdf_reader.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 
 import numpy as np
@@ -8,11 +9,17 @@ import pytest
 
 from cdm_reader_mapper import test_data, DataBundle
 from cdm_reader_mapper.mdf_reader.reader import (
+    _read_data,
     read_mdf,
     read_data,
     validate_read_mdf_args,
 )
 from cdm_reader_mapper.mdf_reader.utils.filereader import _apply_multiindex
+from cdm_reader_mapper.mdf_reader.utils.utilities import (
+    read_csv,
+    read_parquet,
+    read_feather,
+)
 
 
 def _get_columns(columns, select):
@@ -226,7 +233,7 @@ def test_read_data_basic():
     assert isinstance(db.data, pd.DataFrame)
     assert isinstance(db.mask, pd.DataFrame)
     assert isinstance(db.columns, pd.MultiIndex)
-    assert isinstance(db.dtypes, dict)
+    assert isinstance(db.dtypes, pd.Series)
     assert isinstance(db.parse_dates, list)
     assert isinstance(db.encoding, str)
     assert db.encoding == "cp1252"
@@ -261,7 +268,7 @@ def test_read_data_no_mask():
     assert isinstance(db.data, pd.DataFrame)
     assert isinstance(db.mask, pd.DataFrame)
     assert isinstance(db.columns, pd.MultiIndex)
-    assert isinstance(db.dtypes, dict)
+    assert isinstance(db.dtypes, pd.Series)
     assert isinstance(db.parse_dates, list)
     assert isinstance(db.encoding, str)
     assert db.encoding == "cp1252"
@@ -296,7 +303,7 @@ def test_read_data_no_info():
     assert isinstance(db.data, pd.DataFrame)
     assert isinstance(db.mask, pd.DataFrame)
     assert isinstance(db.columns, pd.MultiIndex)
-    assert isinstance(db.dtypes, dict)
+    assert isinstance(db.dtypes, pd.Series)
     assert db.parse_dates is False
     assert db.encoding is None
     assert db.imodel is None
@@ -330,7 +337,7 @@ def test_read_data_col_subset():
     assert isinstance(db.data, pd.DataFrame)
     assert isinstance(db.mask, pd.DataFrame)
     assert isinstance(db.columns, pd.Index)
-    assert isinstance(db.dtypes, dict)
+    assert isinstance(db.dtypes, pd.Series)
     assert isinstance(db.parse_dates, list)
     assert isinstance(db.encoding, str)
     assert db.encoding == "cp1252"
@@ -364,7 +371,7 @@ def test_read_data_encoding():
     assert isinstance(db.data, pd.DataFrame)
     assert isinstance(db.mask, pd.DataFrame)
     assert isinstance(db.columns, pd.Index)
-    assert isinstance(db.dtypes, dict)
+    assert isinstance(db.dtypes, pd.Series)
     assert db.parse_dates is False
     assert isinstance(db.encoding, str)
     assert db.encoding == "cp1252"
@@ -400,7 +407,7 @@ def test_read_data_textfilereader():
     assert isinstance(db.data, pd.io.parsers.TextFileReader)
     assert isinstance(db.mask, pd.io.parsers.TextFileReader)
     assert isinstance(db.columns, pd.MultiIndex)
-    assert isinstance(db.dtypes, dict)
+    assert isinstance(db.dtypes, pd.Series)
     assert db.parse_dates == []
     assert isinstance(db.encoding, str)
     assert db.encoding == "cp1252"
@@ -511,3 +518,208 @@ def test_validate_read_mdf_args_invalid_years(tmp_path):
             chunksize=None,
             skiprows=0,
         )
+
+
+@pytest.fixture
+def example_data():
+    return pd.DataFrame(
+        {
+            "A": [1, 2, 3],
+            "B": [4.0, 5.0, 6.0],
+            "C": ["x", "y", "z"],
+        }
+    )
+
+
+@pytest.fixture
+def example_mask():
+    return pd.DataFrame(
+        {
+            "A": [True, False, True],
+            "B": [True, True, False],
+            "C": [True, True, False],
+        },
+        dtype="boolean",
+    )
+
+
+@pytest.fixture
+def example_info(example_data):
+    return {
+        "columns": example_data.columns,
+        "dtypes": example_data.dtypes,
+        "parse_dates": False,
+        "encoding": None,
+    }
+
+
+@pytest.fixture
+def csv_files(tmp_path, example_data, example_mask, example_info):
+    data_file = tmp_path / "data.csv"
+    mask_file = tmp_path / "mask.csv"
+    info_file = tmp_path / "info.json"
+
+    example_data.to_csv(data_file, index=False)
+    example_mask.to_csv(mask_file, index=False)
+    info = {
+        "columns": list(example_info["columns"]),
+        "dtypes": example_info["dtypes"].astype(str).to_dict(),
+        "parse_dates": example_info["parse_dates"],
+        "encoding": example_info["encoding"],
+    }
+    info_file.write_text(json.dumps(info))
+
+    return data_file, mask_file, info_file
+
+
+@pytest.fixture
+def parquet_files(tmp_path, example_data, example_mask):
+    data_file = tmp_path / "data.parquet"
+    mask_file = tmp_path / "mask.parquet"
+
+    example_data.to_parquet(data_file)
+    example_mask.to_parquet(mask_file)
+
+    return data_file, mask_file
+
+
+@pytest.fixture
+def feather_files(tmp_path, example_data, example_mask):
+    data_file = tmp_path / "data.feather"
+    mask_file = tmp_path / "mask.feather"
+
+    example_data.to_feather(data_file)
+    example_mask.to_feather(mask_file)
+
+    return data_file, mask_file
+
+
+def test_read_data_with_mask_csv(csv_files, example_data, example_mask, example_info):
+    data_file, mask_file, _ = csv_files
+    data, mask, info = _read_data(
+        data_file=data_file,
+        mask_file=mask_file,
+        reader=read_csv,
+        col_subset=None,
+        data_kwargs={},
+        mask_kwargs={"dtype": "boolean"},
+    )
+    pd.testing.assert_frame_equal(data, example_data)
+    pd.testing.assert_frame_equal(mask, example_mask)
+    pd.testing.assert_index_equal(info["columns"], example_info["columns"])
+    pd.testing.assert_series_equal(info["dtypes"], example_info["dtypes"])
+
+
+def test_read_data_with_mask_parquet(
+    parquet_files, example_data, example_mask, example_info
+):
+    data_file, mask_file = parquet_files
+    data, mask, info = _read_data(
+        data_file=data_file,
+        mask_file=mask_file,
+        reader=read_parquet,
+        col_subset=None,
+        data_kwargs={},
+        mask_kwargs={},
+    )
+    pd.testing.assert_frame_equal(data, example_data)
+    pd.testing.assert_frame_equal(mask, example_mask)
+    pd.testing.assert_index_equal(info["columns"], example_info["columns"])
+    pd.testing.assert_series_equal(info["dtypes"], example_info["dtypes"])
+
+
+def test_read_data_with_mask_feather(
+    feather_files, example_data, example_mask, example_info
+):
+    data_file, mask_file = feather_files
+    data, mask, info = _read_data(
+        data_file=data_file,
+        mask_file=mask_file,
+        reader=read_feather,
+        col_subset=None,
+        data_kwargs={},
+        mask_kwargs={},
+    )
+    pd.testing.assert_frame_equal(data, example_data)
+    pd.testing.assert_frame_equal(mask, example_mask)
+    pd.testing.assert_index_equal(info["columns"], example_info["columns"])
+    pd.testing.assert_series_equal(info["dtypes"], example_info["dtypes"])
+
+
+def test_read_data_without_mask_csv(csv_files, example_data, example_info):
+    data_file, _, _ = csv_files
+    data, mask, info = _read_data(
+        data_file=data_file,
+        mask_file=None,
+        reader=read_csv,
+        col_subset=None,
+        data_kwargs={},
+        mask_kwargs={},
+    )
+    pd.testing.assert_frame_equal(data, example_data)
+    assert mask.empty
+    pd.testing.assert_index_equal(info["columns"], example_info["columns"])
+    pd.testing.assert_series_equal(info["dtypes"], example_info["dtypes"])
+
+
+def test_read_data_csv(csv_files, example_data, example_mask):
+    data_file, mask_file, info_file = csv_files
+
+    bundle = read_data(
+        data_file=data_file,
+        mask_file=mask_file,
+        info_file=info_file,
+        data_format="csv",
+    )
+
+    assert isinstance(bundle, DataBundle)
+    pd.testing.assert_frame_equal(bundle.data, example_data)
+    pd.testing.assert_frame_equal(bundle.mask, example_mask)
+    pd.testing.assert_index_equal(bundle.columns, example_data.columns)
+    pd.testing.assert_series_equal(bundle.dtypes, example_data.dtypes)
+    assert bundle.parse_dates is False
+    assert bundle.encoding is None
+    assert bundle.imodel is None
+
+
+def test_read_data_parquet(parquet_files, example_data, example_mask):
+    data_file, mask_file = parquet_files
+
+    bundle = read_data(
+        data_file=data_file,
+        mask_file=mask_file,
+        data_format="parquet",
+    )
+
+    assert isinstance(bundle, DataBundle)
+    pd.testing.assert_frame_equal(bundle.data, example_data)
+    pd.testing.assert_frame_equal(bundle.mask, example_mask)
+    pd.testing.assert_index_equal(bundle.columns, example_data.columns)
+    pd.testing.assert_series_equal(bundle.dtypes, example_data.dtypes)
+    assert bundle.parse_dates is False
+    assert bundle.encoding is None
+    assert bundle.imodel is None
+
+
+def test_read_data_feather(feather_files, example_data, example_mask):
+    data_file, mask_file = feather_files
+
+    bundle = read_data(
+        data_file=data_file,
+        mask_file=mask_file,
+        data_format="feather",
+    )
+
+    assert isinstance(bundle, DataBundle)
+    pd.testing.assert_frame_equal(bundle.data, example_data)
+    pd.testing.assert_frame_equal(bundle.mask, example_mask)
+    pd.testing.assert_index_equal(bundle.columns, example_data.columns)
+    pd.testing.assert_series_equal(bundle.dtypes, example_data.dtypes)
+    assert bundle.parse_dates is False
+    assert bundle.encoding is None
+    assert bundle.imodel is None
+
+
+def test_read_data_invalid():
+    with pytest.raises(ValueError):
+        read_data("data.invalid", data_format="invalid")

--- a/tests/test_reader_convert_and_decode.py
+++ b/tests/test_reader_convert_and_decode.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import get_args
+
 import pandas as pd
 import pytest
 
@@ -13,6 +15,9 @@ from cdm_reader_mapper.mdf_reader.utils.convert_and_decode import (
     convert_and_decode,
 )
 from cdm_reader_mapper.mdf_reader import properties
+
+
+numeric_types = get_args(properties.NumericTypes)
 
 
 @pytest.fixture
@@ -89,7 +94,7 @@ def test_base36_preserves_boolean():
 
 
 def test_converter_numeric(numeric_series):
-    conv = Converters(dtype=next(iter(properties.numeric_types)))
+    conv = Converters(dtype=next(iter(numeric_types)))
     func = conv.converter()
 
     result = func(numeric_series)
@@ -111,7 +116,7 @@ def test_numeric_with_scale_offset():
 
 
 def test_preprocessing_function_pppp():
-    conv = Converters(dtype=next(iter(properties.numeric_types)))
+    conv = Converters(dtype=next(iter(numeric_types)))
     series = pd.Series(["0123"], name="PPPP")
 
     result = conv.object_to_numeric(series)

--- a/tests/test_reader_utilities.py
+++ b/tests/test_reader_utilities.py
@@ -178,9 +178,8 @@ def test_read_csv_file_exists(tmp_csv_file):
 
 def test_read_csv_file_missing(tmp_path):
     missing_file = tmp_path / "missing.csv"
-    df, info = read_csv(missing_file)
-    assert df.empty
-    assert info == {}
+    with pytest.raises(FileNotFoundError):
+        read_csv(missing_file)
 
 
 def test_read_csv_with_col_subset(tmp_csv_file):

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -14,8 +14,9 @@ def db_exp():
     for table in cdm_tables:
         cdm_path = test_data[pattern][f"cdm_{table}"].parent
 
-    db = read(cdm_path, suffix=f"{imodel}*", mode="tables")
+    db = read(cdm_path, suffix=f"{imodel}*", extension="psv", mode="tables")
     db.imodel = imodel
+    print(db)
     return db
 
 
@@ -28,11 +29,19 @@ def test_write_data(tmp_path, db_exp):
 def test_write_header(tmp_path, db_exp):
     table = "header"
     db_exp.write(
-        out_dir=tmp_path, suffix=f"{db_exp.imodel}_{table}_all", cdm_subset=table
+        out_dir=tmp_path,
+        suffix=f"{db_exp.imodel}_{table}_all",
+        extension="psv",
+        cdm_subset=table,
     )
     db_res = read(
-        tmp_path, suffix=f"{db_exp.imodel}_{table}_all", cdm_subset=table, mode="tables"
+        tmp_path,
+        suffix=f"{db_exp.imodel}_{table}_all",
+        cdm_subset=table,
+        extension="psv",
+        mode="tables",
     )
+
     table_exp = db_exp[table].dropna(how="all").reset_index(drop=True)
     pd.testing.assert_frame_equal(table_exp, db_res[table])
 
@@ -88,8 +97,13 @@ def test_write_filename_dict_observations(tmp_path, db_exp):
     filename_dict = {
         "observations-sst": f"observations-sst-{db_exp.imodel}_filename_dict_all.psv",
     }
-    db_exp.write(out_dir=tmp_path, filename=filename_dict)
-    db_res = read(tmp_path, suffix=f"{db_exp.imodel}_filename_dict_all", mode="tables")
+    db_exp.write(out_dir=tmp_path, filename=filename_dict, extension="psv")
+    db_res = read(
+        tmp_path,
+        suffix=f"{db_exp.imodel}_filename_dict_all",
+        mode="tables",
+        extension="psv",
+    )
     table_exp = db_exp["observations-sst"].dropna(how="all").reset_index(drop=True)
     pd.testing.assert_frame_equal(table_exp, db_res.data["observations-sst"])
 

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -34,7 +34,18 @@ def db_data():
     return db
 
 
-def test_write_data(tmp_path, db_tables):
+def test_write_data_csv(tmp_path, db_data):
+    db_data.write(out_dir=tmp_path, data_format="csv")
+    db_res = read(
+        os.path.join(tmp_path, "data.csv"),
+        info_file=os.path.join(tmp_path, "info.json"),
+        data_format="csv",
+        mode="data",
+    )
+    pd.testing.assert_frame_equal(db_data.data, db_res.data)
+
+
+def test_write_tables_csv(tmp_path, db_tables):
     db_tables.write(out_dir=tmp_path, suffix=f"{db_tables.imodel}_all")
     db_res = read(tmp_path, suffix=f"{db_tables.imodel}_all", mode="tables")
     pd.testing.assert_frame_equal(db_tables.data, db_res.data)
@@ -141,7 +152,7 @@ def test_write_col_subset(tmp_path, db_tables):
     pd.testing.assert_frame_equal(table_exp, db_res[table])
 
 
-def test_write_parquet(tmp_path, db_data):
+def test_write_data_parquet(tmp_path, db_data):
     db_data.write(out_dir=tmp_path, data_format="parquet")
     db_res = read(
         os.path.join(tmp_path, "data.parquet"), data_format="parquet", mode="data"
@@ -149,9 +160,29 @@ def test_write_parquet(tmp_path, db_data):
     pd.testing.assert_frame_equal(db_data.data, db_res.data)
 
 
-def test_write_feather(tmp_path, db_data):
+def test_write_data_feather(tmp_path, db_data):
     db_data.write(out_dir=tmp_path, data_format="feather")
     db_res = read(
         os.path.join(tmp_path, "data.feather"), data_format="feather", mode="data"
     )
     pd.testing.assert_frame_equal(db_data.data, db_res.data)
+
+
+def test_write_tables_parquet(tmp_path, db_tables):
+    db_tables.write(
+        out_dir=tmp_path, suffix=f"{db_tables.imodel}_all", data_format="parquet"
+    )
+    db_res = read(
+        tmp_path, suffix=f"{db_tables.imodel}_all", mode="tables", data_format="parquet"
+    )
+    pd.testing.assert_frame_equal(db_tables.data, db_res.data)
+
+
+def test_write_tables_feather(tmp_path, db_tables):
+    db_tables.write(
+        out_dir=tmp_path, suffix=f"{db_tables.imodel}_all", data_format="feather"
+    )
+    db_res = read(
+        tmp_path, suffix=f"{db_tables.imodel}_all", mode="tables", data_format="feather"
+    )
+    pd.testing.assert_frame_equal(db_tables.data, db_res.data)

--- a/tests/test_writers.py
+++ b/tests/test_writers.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+
 import pandas as pd
 import pytest  # noqa
 
@@ -8,7 +10,7 @@ from cdm_reader_mapper.cdm_mapper.properties import cdm_tables
 
 
 @pytest.fixture(scope="session")
-def db_exp():
+def db_tables():
     imodel = "icoads_r300_d714"
     pattern = f"test_{imodel}"
     for table in cdm_tables:
@@ -16,107 +18,140 @@ def db_exp():
 
     db = read(cdm_path, suffix=f"{imodel}*", extension="psv", mode="tables")
     db.imodel = imodel
-    print(db)
     return db
 
 
-def test_write_data(tmp_path, db_exp):
-    db_exp.write(out_dir=tmp_path, suffix=f"{db_exp.imodel}_all")
-    db_res = read(tmp_path, suffix=f"{db_exp.imodel}_all", mode="tables")
-    pd.testing.assert_frame_equal(db_exp.data, db_res.data)
+@pytest.fixture(scope="session")
+def db_data():
+    imodel = "icoads_r300_d714"
+    pattern = f"test_{imodel}"
+
+    data_file = test_data[pattern]["mdf_data"]
+    info_file = test_data[pattern]["mdf_info"]
+
+    db = read(data_file, info_file=info_file, mode="data")
+    db.imodel = imodel
+    return db
 
 
-def test_write_header(tmp_path, db_exp):
+def test_write_data(tmp_path, db_tables):
+    db_tables.write(out_dir=tmp_path, suffix=f"{db_tables.imodel}_all")
+    db_res = read(tmp_path, suffix=f"{db_tables.imodel}_all", mode="tables")
+    pd.testing.assert_frame_equal(db_tables.data, db_res.data)
+
+
+def test_write_header(tmp_path, db_tables):
     table = "header"
-    db_exp.write(
+    db_tables.write(
         out_dir=tmp_path,
-        suffix=f"{db_exp.imodel}_{table}_all",
+        suffix=f"{db_tables.imodel}_{table}_all",
         extension="psv",
         cdm_subset=table,
     )
     db_res = read(
         tmp_path,
-        suffix=f"{db_exp.imodel}_{table}_all",
+        suffix=f"{db_tables.imodel}_{table}_all",
         cdm_subset=table,
         extension="psv",
         mode="tables",
     )
 
-    table_exp = db_exp[table].dropna(how="all").reset_index(drop=True)
+    table_exp = db_tables[table].dropna(how="all").reset_index(drop=True)
     pd.testing.assert_frame_equal(table_exp, db_res[table])
 
 
-def test_write_observations(tmp_path, db_exp):
+def test_write_observations(tmp_path, db_tables):
     table = "observations-sst"
-    db_exp.write(
-        out_dir=tmp_path, suffix=f"{db_exp.imodel}_{table}_all", cdm_subset=table
+    db_tables.write(
+        out_dir=tmp_path, suffix=f"{db_tables.imodel}_{table}_all", cdm_subset=table
     )
     db_res = read(
-        tmp_path, suffix=f"{db_exp.imodel}_{table}_all", cdm_subset=table, mode="tables"
+        tmp_path,
+        suffix=f"{db_tables.imodel}_{table}_all",
+        cdm_subset=table,
+        mode="tables",
     )
-    table_exp = db_exp[table].dropna(how="all").reset_index(drop=True)
+    table_exp = db_tables[table].dropna(how="all").reset_index(drop=True)
     pd.testing.assert_frame_equal(table_exp, db_res[table])
 
 
-def test_write_fns(tmp_path, db_exp):
-    db_exp.write(
+def test_write_fns(tmp_path, db_tables):
+    db_tables.write(
         out_dir=tmp_path,
         prefix="prefix",
-        suffix=f"{db_exp.imodel}_all",
+        suffix=f"{db_tables.imodel}_all",
         extension="csv",
         delimiter=",",
     )
     db_res = read(
         tmp_path,
         prefix="prefix",
-        suffix=f"{db_exp.imodel}_all",
+        suffix=f"{db_tables.imodel}_all",
         extension="csv",
         delimiter=",",
         mode="tables",
     )
-    pd.testing.assert_frame_equal(db_exp.data, db_res.data)
+    pd.testing.assert_frame_equal(db_tables.data, db_res.data)
 
 
-def test_write_filename(tmp_path, db_exp):
-    db_exp.write(out_dir=tmp_path, filename=f"{db_exp.imodel}_filename_all")
-    db_res = read(tmp_path, suffix=f"{db_exp.imodel}_filename_all", mode="tables")
-    pd.testing.assert_frame_equal(db_exp.data, db_res.data)
+def test_write_filename(tmp_path, db_tables):
+    db_tables.write(out_dir=tmp_path, filename=f"{db_tables.imodel}_filename_all")
+    db_res = read(tmp_path, suffix=f"{db_tables.imodel}_filename_all", mode="tables")
+    pd.testing.assert_frame_equal(db_tables.data, db_res.data)
 
 
-def test_write_filename_dict_header(tmp_path, db_exp):
+def test_write_filename_dict_header(tmp_path, db_tables):
     filename_dict = {
-        "header": f"{db_exp.imodel}_filename_dict_all",
+        "header": f"{db_tables.imodel}_filename_dict_all",
     }
-    db_exp.write(out_dir=tmp_path, filename=filename_dict)
-    db_res = read(tmp_path, suffix=f"{db_exp.imodel}_filename_dict_all", mode="tables")
-    table_exp = db_exp["header"].dropna(how="all").reset_index(drop=True)
+    db_tables.write(out_dir=tmp_path, filename=filename_dict)
+    db_res = read(
+        tmp_path, suffix=f"{db_tables.imodel}_filename_dict_all", mode="tables"
+    )
+    table_exp = db_tables["header"].dropna(how="all").reset_index(drop=True)
     pd.testing.assert_frame_equal(table_exp, db_res.data["header"])
 
 
-def test_write_filename_dict_observations(tmp_path, db_exp):
+def test_write_filename_dict_observations(tmp_path, db_tables):
     filename_dict = {
-        "observations-sst": f"observations-sst-{db_exp.imodel}_filename_dict_all.psv",
+        "observations-sst": f"observations-sst-{db_tables.imodel}_filename_dict_all.psv",
     }
-    db_exp.write(out_dir=tmp_path, filename=filename_dict, extension="psv")
+    db_tables.write(out_dir=tmp_path, filename=filename_dict, extension="psv")
     db_res = read(
         tmp_path,
-        suffix=f"{db_exp.imodel}_filename_dict_all",
+        suffix=f"{db_tables.imodel}_filename_dict_all",
         mode="tables",
         extension="psv",
     )
-    table_exp = db_exp["observations-sst"].dropna(how="all").reset_index(drop=True)
+    table_exp = db_tables["observations-sst"].dropna(how="all").reset_index(drop=True)
     pd.testing.assert_frame_equal(table_exp, db_res.data["observations-sst"])
 
 
-def test_write_col_subset(tmp_path, db_exp):
+def test_write_col_subset(tmp_path, db_tables):
     table = "header"
     columns = ["report_id", "latitude", "longitude"]
-    db_exp.write(
+    db_tables.write(
         out_dir=tmp_path,
-        suffix=f"{db_exp.imodel}_{table}_all",
+        suffix=f"{db_tables.imodel}_{table}_all",
         cdm_subset=table,
         col_subset={table: columns},
     )
-    db_res = read(tmp_path, suffix=f"{db_exp.imodel}_{table}_all", mode="tables")
-    table_exp = db_exp[table][columns].dropna(how="all").reset_index(drop=True)
+    db_res = read(tmp_path, suffix=f"{db_tables.imodel}_{table}_all", mode="tables")
+    table_exp = db_tables[table][columns].dropna(how="all").reset_index(drop=True)
     pd.testing.assert_frame_equal(table_exp, db_res[table])
+
+
+def test_write_parquet(tmp_path, db_data):
+    db_data.write(out_dir=tmp_path, data_format="parquet")
+    db_res = read(
+        os.path.join(tmp_path, "data.parquet"), data_format="parquet", mode="data"
+    )
+    pd.testing.assert_frame_equal(db_data.data, db_res.data)
+
+
+def test_write_feather(tmp_path, db_data):
+    db_data.write(out_dir=tmp_path, data_format="feather")
+    db_res = read(
+        os.path.join(tmp_path, "data.feather"), data_format="feather", mode="data"
+    )
+    pd.testing.assert_frame_equal(db_data.data, db_res.data)


### PR DESCRIPTION
This PR fixes #353. 

- [x] ``mdf_reader``: read `parquet`
- [x] ``mdf_reader``: read `feather`
- [x] ``cdm_mapper``: read `parquet` 
- [x] ``cdm_mapper``: read `feather`
- [x] add unit tests
- [x] update `CHANGELOG`