### PR TITLE
Reject new updates detected with Cruft

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/Ouranosinc/cookiecutter-pypackage.git",
-  "commit": "cb8b26cb78a428f6ce447a0ab1b08c0c171ad5aa",
+  "commit": "3c1f362148b15e97a7a7d252f39f40d4175dfcb2",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -20,10 +20,22 @@
       "command_line_interface": "Click",
       "create_author_file": "y",
       "open_source_license": "Apache Software License 2.0",
+      "ai_tools_policy": "Standard",
       "generated_with_cruft": "n",
       "__gh_slug": "https://github.com/glamod/cdm_reader_mapper",
+      "_copy_without_render": [
+        ".github/workflows/auto-accept-ci-changes.yml",
+        ".github/workflows/cache-cleaner.yml",
+        ".github/workflows/codeql.yml",
+        ".github/workflows/dependency-review.yml",
+        ".github/workflows/label.yml",
+        ".github/workflows/publish-pypi.yml",
+        ".github/workflows/scorecard.yml",
+        ".github/workflows/tag-testpypi.yml",
+        ".github/workflows/workflow-warning.yml"
+      ],
       "_template": "https://github.com/Ouranosinc/cookiecutter-pypackage.git",
-      "_commit": "cb8b26cb78a428f6ce447a0ab1b08c0c171ad5aa"
+      "_commit": "3c1f362148b15e97a7a7d252f39f40d4175dfcb2"
     }
   },
   "directory": null


### PR DESCRIPTION
This is an autogenerated PR. Use this to reject the changes in this repository.
[Cruft](https://cruft.github.io/cruft/) has detected updates from the Cookiecutter repository.